### PR TITLE
Pertially implemented the GP "TEE Client API" & HelloWorld test

### DIFF
--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/FreeRTOSConfig.h
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/FreeRTOSConfig.h
@@ -20,48 +20,51 @@
 	extern uint32_t SystemCoreClock;
 #endif
 
-#define configUSE_PREEMPTION			1
-#define configUSE_IDLE_HOOK				0
-#define configUSE_TICK_HOOK				0
-#define configCPU_CLOCK_HZ				( SystemCoreClock )
-#define configTICK_RATE_HZ				( ( TickType_t ) 200 ) /* if value upper then 200 to need fix issue related SysTick in Secure world */
-#define configMAX_PRIORITIES			( 8 )
-#define configMINIMAL_STACK_SIZE		( ( unsigned short ) 128 )
-#define configTOTAL_HEAP_SIZE			( ( size_t ) ( 0x2000 ) )
-#define configMAX_TASK_NAME_LEN			( 8 )
-#define configUSE_TRACE_FACILITY		1
-#define configUSE_16_BIT_TICKS			0
-#define configIDLE_SHOULD_YIELD			1
-#define configUSE_MUTEXES				1
-#define configQUEUE_REGISTRY_SIZE		8
-#define configCHECK_FOR_STACK_OVERFLOW	2
-#define configUSE_RECURSIVE_MUTEXES		1
-#define configUSE_MALLOC_FAILED_HOOK	1
-#define configUSE_APPLICATION_TASK_TAG	0
-#define configUSE_COUNTING_SEMAPHORES	1
-#define configGENERATE_RUN_TIME_STATS	0
-#define configUSE_QUEUE_SETS			1
+#define configUSE_PREEMPTION            1
+#define configUSE_IDLE_HOOK             0
+#define configUSE_TICK_HOOK             0
+#define configCPU_CLOCK_HZ              ( SystemCoreClock )
+#define configTICK_RATE_HZ              ( ( TickType_t ) 200 ) /* if value upper then 200 to need fix issue related SysTick in Secure world */
+#define configMAX_PRIORITIES            ( 8 )
+#define configMINIMAL_STACK_SIZE        ( ( unsigned short ) 128 )
+#define configTOTAL_HEAP_SIZE           ( ( size_t ) ( 0x2000 ) )
+#define configMAX_TASK_NAME_LEN         ( 12 )
+#define configUSE_TRACE_FACILITY        1
+#define configUSE_16_BIT_TICKS          0
+#define configIDLE_SHOULD_YIELD         1
+#define configUSE_MUTEXES               1
+#define configQUEUE_REGISTRY_SIZE       8
+#define configCHECK_FOR_STACK_OVERFLOW  2
+#define configUSE_RECURSIVE_MUTEXES     1
+#define configUSE_MALLOC_FAILED_HOOK    1
+#define configUSE_APPLICATION_TASK_TAG  0
+#define configUSE_COUNTING_SEMAPHORES   1
+#define configGENERATE_RUN_TIME_STATS   0
+#define configUSE_QUEUE_SETS            1
 
 /* Co-routine definitions. */
-#define configUSE_CO_ROUTINES 			0
+#define configUSE_CO_ROUTINES           0
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 
 /* Software timer definitions. */
-#define configUSE_TIMERS				1
-#define configTIMER_TASK_PRIORITY		( 2 )
-#define configTIMER_QUEUE_LENGTH		5
-#define configTIMER_TASK_STACK_DEPTH	( 80 )
+#define configUSE_TIMERS                1
+#define configTIMER_TASK_PRIORITY       ( 2 )
+#define configTIMER_QUEUE_LENGTH        5
+#define configTIMER_TASK_STACK_DEPTH    ( 80 )
+
+#define configUSE_TRACE_FACILITY              1
+#define configUSE_STATS_FORMATTING_FUNCTIONS  1
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */
-#define INCLUDE_vTaskPrioritySet		1
-#define INCLUDE_uxTaskPriorityGet		1
-#define INCLUDE_vTaskDelete				1
-#define INCLUDE_vTaskCleanUpResources	1
-#define INCLUDE_vTaskSuspend			1
-#define INCLUDE_vTaskDelayUntil			1
-#define INCLUDE_vTaskDelay				1
-#define INCLUDE_eTaskGetState			1
+#define INCLUDE_vTaskPrioritySet        1
+#define INCLUDE_uxTaskPriorityGet       1
+#define INCLUDE_vTaskDelete             1
+#define INCLUDE_vTaskCleanUpResources   1
+#define INCLUDE_vTaskSuspend            1
+#define INCLUDE_vTaskDelayUntil         1
+#define INCLUDE_vTaskDelay              1
+#define INCLUDE_eTaskGetState           1
 
 /* Normal assert() semantics without relying on the provision of an assert.h
 header file. */

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Make.defs
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Make.defs
@@ -32,5 +32,8 @@ CHIP_ASRCS_NS = ../../Device/Nuvoton/M2351/Source/GCC/startup_M2351.S
 
 CHIP_CSRCS_NS = ../../Device/Nuvoton/M2351/Source/system_M2351.c \
                 ../../Device/Nuvoton/M2351/Source/GCC/_syscalls.c \
-                main_ns.c
+                main_ns.c \
+                ../../../../../../apps/hello_world/ca/hello_world_ns.c \
+                ../../../../../../tee_client/libteec/src/tee_client_api.c
+                
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Makefile
@@ -29,6 +29,9 @@ CFLAGS += -I../../Device/Nuvoton/M2351/Include
 CFLAGS += -I$(TOPDIR)/include/mtower
 CFLAGS += -I$(TOPDIR)/freertos/include
 CFLAGS += -I$(TOPDIR)/freertos/portable/GCC/ARM_V8M
+CFLAGS += -I$(TOPDIR)/tee_client/public
+CFLAGS += -I$(TOPDIR)/tee_client/libteec/include/freertos
+CFLAGS += -I$(TOPDIR)/apps/hello_world
 
 CFLAGS += -DDEBUG_PORT=UART1_NS
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Make.defs
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Make.defs
@@ -32,5 +32,6 @@ CHIP_ASRCS_S = ../../Device/Nuvoton/M2351/Source/GCC/startup_M2351.S
 
 CHIP_CSRCS_S = ../../Device/Nuvoton/M2351/Source/system_M2351.c \
                ../../Device/Nuvoton/M2351/Source/GCC/_syscalls.c \
-               main.c
+               main.c \
+               tee_core.c
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Makefile
@@ -27,6 +27,10 @@ CFLAGS += -I$(TOPDIR)/include/mtower
 CFLAGS += -I../../CMSIS/Include
 CFLAGS += -I../../StdDriver/inc
 CFLAGS += -I../../Device/Nuvoton/M2351/Include
+CFLAGS += -I$(TOPDIR)/tee_client/public
+CFLAGS += -I$(TOPDIR)/tee_client/libteec/include/freertos
+CFLAGS += -I$(TOPDIR)/apps/hello_world
+
 
 OBJDIR = $(TOPDIR)/build/secure$(subst $(TOPDIR),,$(shell pwd))
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/main.c
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/main.c
@@ -353,7 +353,7 @@ int main(void)
   GPIO_SetMode(PB, BIT1 | BIT0, GPIO_MODE_OUTPUT);
 
   /* Generate Systick interrupt each 10 ms */
-  SysTick_Config(SystemCoreClock / 100);
+//  SysTick_Config(SystemCoreClock / 100);
 
   /* Set GPIO Port C to non-secure for LED control */
   SCU_SET_IONSSET(SCU_IONSSET_PC_Msk);

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/tee_core.c
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/tee_core.c
@@ -1,0 +1,196 @@
+/**
+ * @file        arch/arm/m2351/src/numaker_pfm_m2351/secure/tee_core.c
+ * @brief       Provides functionality to start secure world, initialize secure
+ *              and normal worlds, pass to execution to normal world.
+ *
+ * @copyright   Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved.
+ * @author      Taras Drozdovskyi t.drozdovsky@samsung.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Included Files. */
+#include <arm_cmse.h>
+#include <stdio.h>
+#include "M2351.h"
+#include "partition_M2351.h"
+
+/* GP TEE client API */
+#include "tee_types.h"
+#include "tee_client_api.h"
+#include "tee.h"
+
+/* Pre-processor Definitions. */
+
+
+/* Private Types. */
+/* Any types, enums, structures or unions used by the file are defined here. */
+/* typedef for NonSecure callback functions */
+typedef __NONSECURE_CALL int32_t (*NonSecure_funcptr)(uint32_t);
+typedef int32_t (*Secure_funcptr)(uint32_t);
+
+/* Private Function Prototypes. */
+/* Prototypes of all static functions in the file are provided here. */
+
+
+/* Private Data. */
+/* All static data definitions appear here. */
+
+
+/* Public Data. */
+/* All data definitions with global scope appear here. */
+
+
+/* Public Function Prototypes */
+
+
+/* Private Functions. */
+TEEC_Result tee_ioctl_open_session(/*ctx,*/ struct tee_ioctl_buf_data *buf_data);
+TEEC_Result tee_ioctl_invoke(/*ctx,*/ struct tee_ioctl_buf_data *buf_data);
+TEEC_Result tee_ioctl_close_session(/*ctx,*/ struct tee_ioctl_close_session_arg *arg);
+
+/* Public Functions. */
+
+/* Secure functions exported to NonSecure application. Must place in Non-secure
+ * Callable */
+
+/**
+ * @brief         ioctl - .
+ *
+ * @param         None
+ *
+ * @returns       None
+ */
+__NONSECURE_ENTRY
+int32_t ioctl(uint32_t cmd, struct tee_ioctl_buf_data *buf_data)
+{
+  printf("Secure ioctl: cmd = %x\n", cmd);
+
+  switch (cmd) {
+//  case TEE_IOC_VERSION:
+//    return tee_ioctl_version(ctx, uarg);
+//  case TEE_IOC_SHM_ALLOC:
+//    return tee_ioctl_shm_alloc(ctx, uarg);
+//  case TEE_IOC_SHM_REGISTER:
+//    return tee_ioctl_shm_register(ctx, uarg);
+//  case TEE_IOC_SHM_REGISTER_FD:
+//    return tee_ioctl_shm_register_fd(ctx, uarg);
+  case TEE_IOC_OPEN_SESSION:
+    return tee_ioctl_open_session(/*ctx,*/ buf_data);
+  case TEE_IOC_INVOKE:
+    return tee_ioctl_invoke(/*ctx,*/ buf_data);
+//  case TEE_IOC_CANCEL:
+//    return tee_ioctl_cancel(ctx, uarg);
+  case TEE_IOC_CLOSE_SESSION:
+    return tee_ioctl_close_session(/*ctx,*/ buf_data);
+//  case TEE_IOC_SUPPL_RECV:
+//    return tee_ioctl_supp_recv(ctx, uarg);
+//  case TEE_IOC_SUPPL_SEND:
+//    return tee_ioctl_supp_send(ctx, uarg);
+  default:
+    return TEEC_ERROR_ITEM_NOT_FOUND;
+  }
+
+  return TEEC_SUCCESS;
+}
+
+/**
+ * struct tee_ioctl_open_session_arg - Open session argument
+ * @uuid: [in] UUID of the Trusted Application
+ * @clnt_uuid:  [in] UUID of client
+ * @clnt_login: [in] Login class of client, TEE_IOCTL_LOGIN_* above
+ * @cancel_id:  [in] Cancellation id, a unique value to identify this request
+ * @session:  [out] Session id
+ * @ret:  [out] return value
+ * @ret_origin  [out] origin of the return value
+ * @num_params  [in] number of parameters following this struct
+ */
+//struct tee_ioctl_open_session_arg {
+//  uint8_t uuid[TEE_IOCTL_UUID_LEN];
+//  uint8_t clnt_uuid[TEE_IOCTL_UUID_LEN];
+//  uint32_t clnt_login;
+//  uint32_t cancel_id;
+//  uint32_t session;
+//  uint32_t ret;
+//  uint32_t ret_origin;
+//  uint32_t num_params;
+
+static void uuid_print(uint8_t d[TEE_IOCTL_UUID_LEN])
+{
+//  printf("UUID = %08x\n",
+//      ((uint32_t) (d[0] << 24)) | (uint32_t) (d[1] << 16)
+//          | (uint32_t) (d[2] << 8) | (uint32_t) d[3]);
+
+  TEEC_UUID s;
+  int i;
+  s.timeLow = ((uint32_t)d[0] << 24);
+  s.timeLow |= ((uint32_t)d[1] << 16);
+  s.timeLow |= ((uint32_t)d[2] << 8);
+  s.timeLow |= ((uint32_t)d[3]);
+  s.timeMid = ((uint16_t)d[4] << 8);
+  s.timeMid |= ((uint16_t)d[5]);
+  s.timeHiAndVersion = ((uint16_t)d[6] << 8);
+  s.timeHiAndVersion |= ((uint16_t)d[7]);
+  memcpy(s.clockSeqAndNode, d + 8, sizeof(s.clockSeqAndNode));
+
+  printf("UUID = %08x-%04x-%04x", s.timeLow, s.timeMid, s.timeHiAndVersion);
+  for (i = 0; i < 8; ++i) {
+    printf("-%02x",s.clockSeqAndNode[i]);
+  }
+  printf("\n");
+}
+
+TEEC_Result tee_ioctl_open_session(/*ctx,*/ struct tee_ioctl_buf_data *buf_data)
+{
+  struct tee_ioctl_open_session_arg *arg;
+  struct tee_ioctl_param *params;
+
+  arg = buf_data->buf_ptr;
+  params = (struct tee_ioctl_param *)(arg + 1);
+  printf("arg->num_params = %d\n", arg->num_params);
+  printf("arg->session = %d\n", arg->session);
+  arg->session = 2;
+  printf("arg->session = %d\n", arg->session);
+
+  uuid_print(arg->uuid);
+
+  return TEEC_SUCCESS;
+}
+
+TEEC_Result tee_ioctl_invoke(/*ctx,*/ struct tee_ioctl_buf_data *buf_data)
+{
+  struct tee_ioctl_invoke_arg *arg;
+  struct tee_ioctl_param *params;
+
+  arg = buf_data->buf_ptr;
+  params = (struct tee_ioctl_param *)(arg + 1);
+  printf("arg->num_params = %d\n", arg->num_params);
+  printf("arg->session = %d\n", arg->session);
+  printf("params->u.value.a = %d\n", params->u.value.a);
+  params->u.value.a++;
+
+
+  return TEEC_SUCCESS;
+}
+
+TEEC_Result tee_ioctl_close_session(/*ctx,*/ struct tee_ioctl_close_session_arg *arg)
+{
+//  struct tee_ioctl_close_session_arg *arg;
+
+//  arg = buf_data->buf_ptr;
+  printf("arg->session = %d\n", arg->session);
+  arg->session = 0;
+
+  return TEEC_SUCCESS;
+}
+

--- a/tee_client/libteec/include/freertos/tee.h
+++ b/tee_client/libteec/include/freertos/tee.h
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2015-2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __TEE_H
+#define __TEE_H
+
+//#include <linux/ioctl.h>
+//#include <linux/types.h>
+
+/*
+ * This file describes the API provided by a TEE driver to user space.
+ *
+ * Each TEE driver defines a TEE specific protocol which is used for the
+ * data passed back and forth using TEE_IOC_CMD.
+ */
+
+/* Helpers to make the ioctl defines */
+#define TEE_IOC_MAGIC	0xa4
+#define TEE_IOC_BASE  0
+#define TEE_IOC_OPEN_SESSION TEE_IOC_BASE + 2
+#define TEE_IOC_INVOKE TEE_IOC_BASE + 3
+#define TEE_IOC_CLOSE_SESSION TEE_IOC_BASE + 5
+
+
+/* Flags relating to shared memory */
+#define TEE_IOCTL_SHM_MAPPED	0x1	/* memory mapped in normal world */
+#define TEE_IOCTL_SHM_DMA_BUF	0x2	/* dma-buf handle on shared memory */
+
+#define TEE_MAX_ARG_SIZE	1024
+
+#define TEE_GEN_CAP_GP		(1 << 0)/* GlobalPlatform compliant TEE */
+#define TEE_GEN_CAP_REG_MEM	(1 << 2)/* Supports registering shared memory */
+
+/*
+ * TEE Implementation ID
+ */
+#define TEE_IMPL_ID_OPTEE	1
+
+/*
+ * OP-TEE specific capabilities
+ */
+#define TEE_OPTEE_CAP_TZ	(1 << 0)
+
+/**
+ * struct tee_ioctl_version_data - TEE version
+ * @impl_id:	[out] TEE implementation id
+ * @impl_caps:	[out] Implementation specific capabilities
+ * @gen_caps:	[out] Generic capabilities, defined by TEE_GEN_CAPS_* above
+ *
+ * Identifies the TEE implementation, @impl_id is one of TEE_IMPL_ID_* above.
+ * @impl_caps is implementation specific, for example TEE_OPTEE_CAP_*
+ * is valid when @impl_id == TEE_IMPL_ID_OPTEE.
+ */
+struct tee_ioctl_version_data {
+	uint32_t impl_id;
+	uint32_t impl_caps;
+	uint32_t gen_caps;
+};
+
+/**
+ * TEE_IOC_VERSION - query version of TEE
+ *
+ * Takes a tee_ioctl_version_data struct and returns with the TEE version
+ * data filled in.
+ */
+#define TEE_IOC_VERSION		_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 0, \
+				     struct tee_ioctl_version_data)
+
+/**
+ * struct tee_ioctl_shm_alloc_data - Shared memory allocate argument
+ * @size:	[in/out] Size of shared memory to allocate
+ * @flags:	[in/out] Flags to/from allocation.
+ * @id:		[out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_ALLOC below.
+ */
+struct tee_ioctl_shm_alloc_data {
+	uint32_t size;
+	uint32_t flags;
+	int32_t id;
+};
+
+/**
+ * TEE_IOC_SHM_ALLOC - allocate shared memory
+ *
+ * Allocates shared memory between the user space process and secure OS.
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The returned file descriptor is used to map the shared memory into user
+ * space. The shared memory is freed when the descriptor is closed and the
+ * memory is unmapped.
+ */
+#define TEE_IOC_SHM_ALLOC	_IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 1, \
+				     struct tee_ioctl_shm_alloc_data)
+
+/**
+ * struct tee_ioctl_shm_register_fd_data - Shared memory registering argument
+ * @fd:		[in] file descriptor identifying the shared memory
+ * @size:	[out] Size of shared memory to allocate
+ * @flags:	[in] Flags to/from allocation.
+ * @id:		[out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_ALLOC below.
+ */
+struct tee_ioctl_shm_register_fd_data {
+  uint32_t fd;
+	uint32_t size;
+	uint32_t flags;
+	int32_t id;
+} __aligned(4);
+
+/**
+ * TEE_IOC_SHM_REGISTER_FD - register a shared memory from a file descriptor
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The returned file descriptor refers to the shared memory object in kernel
+ * land. The shared memory is freed when the descriptor is closed.
+ */
+#define TEE_IOC_SHM_REGISTER_FD	_IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 8, \
+				     struct tee_ioctl_shm_register_fd_data)
+
+/**
+ * struct tee_ioctl_shm_register_data - Shared memory register argument
+ * @addr:      [in] Start address of shared memory to register
+ * @length:    [in/out] Length of shared memory to register
+ * @flags:     [in/out] Flags to/from registration.
+ * @id:                [out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_REGISTER below.
+ */
+struct tee_ioctl_shm_register_data {
+  uint32_t addr;
+  uint32_t length;
+	uint32_t flags;
+	int32_t id;
+};
+
+/**
+ * TEE_IOC_SHM_REGISTER - Register shared memory
+ *
+ * Registers shared memory between the user space process and secure OS.
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The shared memory is unregisterred when the descriptor is closed.
+ */
+#define TEE_IOC_SHM_REGISTER   _IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 9, \
+				     struct tee_ioctl_shm_register_data)
+
+/**
+ * struct tee_ioctl_buf_data - Variable sized buffer
+ * @buf_ptr:	[in] A __user pointer to a buffer
+ * @buf_len:	[in] Length of the buffer above
+ *
+ * Used as argument for TEE_IOC_OPEN_SESSION, TEE_IOC_INVOKE,
+ * TEE_IOC_SUPPL_RECV, and TEE_IOC_SUPPL_SEND below.
+ */
+struct tee_ioctl_buf_data {
+	uint32_t buf_ptr;
+	uint32_t buf_len;
+};
+
+/*
+ * Attributes for struct tee_ioctl_param, selects field in the union
+ */
+#define TEE_IOCTL_PARAM_ATTR_TYPE_NONE		0	/* parameter not used */
+
+/*
+ * These defines value parameters (struct tee_ioctl_param_value)
+ */
+#define TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT	1
+#define TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_OUTPUT	2
+#define TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT	3	/* input and output */
+
+/*
+ * These defines shared memory reference parameters (struct
+ * tee_ioctl_param_memref)
+ */
+#define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT	5
+#define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT	6
+#define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT	7	/* input and output */
+
+/*
+ * Mask for the type part of the attribute, leaves room for more types
+ */
+#define TEE_IOCTL_PARAM_ATTR_TYPE_MASK		0xff
+
+/* Meta parameter carrying extra information about the message. */
+#define TEE_IOCTL_PARAM_ATTR_META		0x100
+
+/* Mask of all known attr bits */
+#define TEE_IOCTL_PARAM_ATTR_MASK \
+	(TEE_IOCTL_PARAM_ATTR_TYPE_MASK | TEE_IOCTL_PARAM_ATTR_META)
+
+/*
+ * Matches TEEC_LOGIN_* in GP TEE Client API
+ * Are only defined for GP compliant TEEs
+ */
+#define TEE_IOCTL_LOGIN_PUBLIC			0
+#define TEE_IOCTL_LOGIN_USER			1
+#define TEE_IOCTL_LOGIN_GROUP			2
+#define TEE_IOCTL_LOGIN_APPLICATION		4
+#define TEE_IOCTL_LOGIN_USER_APPLICATION	5
+#define TEE_IOCTL_LOGIN_GROUP_APPLICATION	6
+
+/**
+ * struct tee_ioctl_param_memref - memory reference
+ * @shm_offs:	Offset into the shared memory object
+ * @size:	Size of the buffer
+ * @shm_id:	Shared memory identifier
+ *
+ * Shared memory is allocated with TEE_IOC_SHM_ALLOC which returns an
+ * identifier representing the shared memory object. A memref can reference
+ * a part of a shared memory by specifying an offset (@shm_offs) and @size
+ * of the object. To supply the entire shared memory object set @shm_offs
+ * to 0 and @size to the previously returned size of the object.
+ */
+struct tee_ioctl_param_memref {
+	uint32_t shm_offs;
+	uint32_t size;
+	int32_t shm_id;
+};
+
+/**
+ * struct tee_ioctl_param_value - values
+ * @a: first value
+ * @b: second value
+ * @c: third value
+ *
+ * Value parameters are passed unchecked to the destination
+ */
+struct tee_ioctl_param_value {
+	uint32_t a;
+	uint32_t b;
+	uint32_t c;
+};
+
+/**
+ * struct tee_ioctl_param - parameter
+ * @attr: attributes
+ * @memref: a memory reference
+ * @value: a value
+ *
+ * @attr & TEE_PARAM_ATTR_TYPE_MASK indicates if memref or value is used in
+ * the union. TEE_PARAM_ATTR_TYPE_VALUE_* indicates value and
+ * TEE_PARAM_ATTR_TYPE_MEMREF_* indicates memref. TEE_PARAM_ATTR_TYPE_NONE
+ * indicates that none of the members are used.
+ */
+struct tee_ioctl_param {
+	uint32_t attr;
+	union {
+		struct tee_ioctl_param_memref memref;
+		struct tee_ioctl_param_value value;
+	} u;
+};
+
+#define TEE_IOCTL_UUID_LEN		16
+
+/**
+ * struct tee_ioctl_open_session_arg - Open session argument
+ * @uuid:	[in] UUID of the Trusted Application
+ * @clnt_uuid:	[in] UUID of client
+ * @clnt_login:	[in] Login class of client, TEE_IOCTL_LOGIN_* above
+ * @cancel_id:	[in] Cancellation id, a unique value to identify this request
+ * @session:	[out] Session id
+ * @ret:	[out] return value
+ * @ret_origin	[out] origin of the return value
+ * @num_params	[in] number of parameters following this struct
+ */
+struct tee_ioctl_open_session_arg {
+	uint8_t uuid[TEE_IOCTL_UUID_LEN];
+	uint8_t clnt_uuid[TEE_IOCTL_UUID_LEN];
+	uint32_t clnt_login;
+	uint32_t cancel_id;
+	uint32_t session;
+	uint32_t ret;
+	uint32_t ret_origin;
+	uint32_t num_params;
+	/*
+	 * this struct is 8 byte aligned since the 'struct tee_ioctl_param'
+	 * which follows requires 8 byte alignment.
+	 *
+	 * Commented out element used to visualize the layout dynamic part
+	 * of the struct. This field is not available at all if
+	 * num_params == 0.
+	 *
+	 * struct tee_ioctl_param params[num_params];
+	 */
+} __aligned(4); //!!! change from 8 to 4
+
+/**
+ * TEE_IOC_OPEN_SESSION - opens a session to a Trusted Application
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_ioctl_open_session_arg followed by any array of struct
+ * tee_ioctl_param
+ */
+//#define TEE_IOC_OPEN_SESSION	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 2, \
+//				     struct tee_ioctl_buf_data)
+
+/**
+ * struct tee_ioctl_invoke_func_arg - Invokes a function in a Trusted
+ * Application
+ * @func:	[in] Trusted Application function, specific to the TA
+ * @session:	[in] Session id
+ * @cancel_id:	[in] Cancellation id, a unique value to identify this request
+ * @ret:	[out] return value
+ * @ret_origin	[out] origin of the return value
+ * @num_params	[in] number of parameters following this struct
+ */
+struct tee_ioctl_invoke_arg {
+	uint32_t func;
+	uint32_t session;
+	uint32_t cancel_id;
+	uint32_t ret;
+	uint32_t ret_origin;
+	uint32_t num_params;
+	/*
+	 * this struct is 8 byte aligned since the 'struct tee_ioctl_param'
+	 * which follows requires 8 byte alignment.
+	 *
+	 * Commented out element used to visualize the layout dynamic part
+	 * of the struct. This field is not available at all if
+	 * num_params == 0.
+	 *
+	 * struct tee_ioctl_param params[num_params];
+	 */
+} __aligned(4);
+
+/**
+ * TEE_IOC_INVOKE - Invokes a function in a Trusted Application
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_invoke_func_arg followed by any array of struct tee_param
+ */
+//#define TEE_IOC_INVOKE		_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 3, \
+//				     struct tee_ioctl_buf_data)
+
+/**
+ * struct tee_ioctl_cancel_arg - Cancels an open session or invoke ioctl
+ * @cancel_id:	[in] Cancellation id, a unique value to identify this request
+ * @session:	[in] Session id, if the session is opened, else set to 0
+ */
+struct tee_ioctl_cancel_arg {
+	uint32_t cancel_id;
+	uint32_t session;
+};
+
+/**
+ * TEE_IOC_CANCEL - Cancels an open session or invoke
+ */
+#define TEE_IOC_CANCEL		_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 4, \
+				     struct tee_ioctl_cancel_arg)
+
+/**
+ * struct tee_ioctl_close_session_arg - Closes an open session
+ * @session:	[in] Session id
+ */
+struct tee_ioctl_close_session_arg {
+	uint32_t session;
+};
+
+/**
+ * TEE_IOC_CLOSE_SESSION - Closes a session
+ */
+//#define TEE_IOC_CLOSE_SESSION	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 5, \
+//				     struct tee_ioctl_close_session_arg)
+
+/**
+ * struct tee_iocl_supp_recv_arg - Receive a request for a supplicant function
+ * @func:	[in] supplicant function
+ * @num_params	[in/out] number of parameters following this struct
+ *
+ * @num_params is the number of params that tee-supplicant has room to
+ * receive when input, @num_params is the number of actual params
+ * tee-supplicant receives when output.
+ */
+struct tee_iocl_supp_recv_arg {
+	uint32_t func;
+	uint32_t num_params;
+	/*
+	 * this struct is 8 byte aligned since the 'struct tee_ioctl_param'
+	 * which follows requires 8 byte alignment.
+	 *
+	 * Commented out element used to visualize the layout dynamic part
+	 * of the struct. This field is not available at all if
+	 * num_params == 0.
+	 *
+	 * struct tee_ioctl_param params[num_params];
+	 */
+} __aligned(4);
+
+/**
+ * TEE_IOC_SUPPL_RECV - Receive a request for a supplicant function
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_iocl_supp_recv_arg followed by any array of struct tee_param
+ */
+#define TEE_IOC_SUPPL_RECV	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 6, \
+				     struct tee_ioctl_buf_data)
+
+/**
+ * struct tee_iocl_supp_send_arg - Send a response to a received request
+ * @ret:	[out] return value
+ * @num_params	[in] number of parameters following this struct
+ */
+struct tee_iocl_supp_send_arg {
+	uint32_t ret;
+	uint32_t num_params;
+	/*
+	 * this struct is 8 byte aligned since the 'struct tee_ioctl_param'
+	 * which follows requires 8 byte alignment.
+	 *
+	 * Commented out element used to visualize the layout dynamic part
+	 * of the struct. This field is not available at all if
+	 * num_params == 0.
+	 *
+	 * struct tee_ioctl_param params[num_params];
+	 */
+} __aligned(4);
+/**
+ * TEE_IOC_SUPPL_SEND - Receive a request for a supplicant function
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_iocl_supp_send_arg followed by any array of struct tee_param
+ */
+#define TEE_IOC_SUPPL_SEND	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 7, \
+				     struct tee_ioctl_buf_data)
+
+/*
+ * Five syscalls are used when communicating with the TEE driver.
+ * open(): opens the device associated with the driver
+ * ioctl(): as described above operating on the file descriptor from open()
+ * close(): two cases
+ *   - closes the device file descriptor
+ *   - closes a file descriptor connected to allocated shared memory
+ * mmap(): maps shared memory into user space using information from struct
+ *	   tee_ioctl_shm_alloc_data
+ * munmap(): unmaps previously shared memory
+ */
+
+#endif /*__TEE_H*/

--- a/tee_client/libteec/src/tee_client_api.c
+++ b/tee_client/libteec/src/tee_client_api.c
@@ -1,0 +1,959 @@
+/*
+ * Copyright (c) 2015-2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+//#include <errno.h>
+//#include <fcntl.h>
+//#include <limits.h>
+//#include <pthread.h>
+#include <stdio.h>
+//#include <stdlib.h>
+#include <string.h>
+//#include <sys/ioctl.h>
+//#include <sys/mman.h>
+//#include <sys/stat.h>
+//#include <sys/types.h>
+//#include <tee_client_api_extensions.h>
+#include "tee_client_api.h"
+#include "tee.h"
+//#include <teec_trace.h>
+//#include <unistd.h>
+//
+//#ifndef __aligned
+//#define __aligned(x) __attribute__((__aligned__(x)))
+//#endif
+//#include <linux/tee.h>
+//
+//#include "teec_benchmark.h"
+
+extern int32_t ioctl(uint32_t cmd, struct tee_ioctl_buf_data *buf_data);
+
+/* How many device sequence numbers will be tried before giving up */
+//#define TEEC_MAX_DEV_SEQ	10
+//
+//static pthread_mutex_t teec_mutex = PTHREAD_MUTEX_INITIALIZER;
+//
+//static void teec_mutex_lock(pthread_mutex_t *mu)
+//{
+//	pthread_mutex_lock(mu);
+//}
+//
+//static void teec_mutex_unlock(pthread_mutex_t *mu)
+//{
+//	pthread_mutex_unlock(mu);
+//}
+//
+//static int teec_open_dev(const char *devname, const char *capabilities,
+//			 uint32_t *gen_caps)
+//{
+//	struct tee_ioctl_version_data vers;
+//	int fd;
+//
+//	fd = open(devname, O_RDWR);
+//	if (fd < 0)
+//		return -1;
+//
+//	if (ioctl(fd, TEE_IOC_VERSION, &vers)) {
+//		EMSG("TEE_IOC_VERSION failed");
+//		goto err;
+//	}
+//
+//	/* We can only handle GP TEEs */
+//	if (!(vers.gen_caps & TEE_GEN_CAP_GP))
+//		goto err;
+//
+//	if (capabilities) {
+//		if (strcmp(capabilities, "optee-tz") == 0) {
+//			if (vers.impl_id != TEE_IMPL_ID_OPTEE)
+//				goto err;
+//			if (!(vers.impl_caps & TEE_OPTEE_CAP_TZ))
+//				goto err;
+//		} else {
+//			/* Unrecognized capability requested */
+//			goto err;
+//		}
+//	}
+//
+//	*gen_caps = vers.gen_caps;
+//	return fd;
+//err:
+//	close(fd);
+//	return -1;
+//}
+//
+//static int teec_shm_alloc(int fd, size_t size, int *id)
+//{
+//	int shm_fd;
+//	struct tee_ioctl_shm_alloc_data data;
+//
+//	memset(&data, 0, sizeof(data));
+//	data.size = size;
+//	shm_fd = ioctl(fd, TEE_IOC_SHM_ALLOC, &data);
+//	if (shm_fd < 0)
+//		return -1;
+//	*id = data.id;
+//	return shm_fd;
+//}
+//
+//static int teec_shm_register(int fd, void *buf, size_t size, int *id)
+//{
+//	int shm_fd;
+//	struct tee_ioctl_shm_register_data data;
+//
+//	memset(&data, 0, sizeof(data));
+//	data.addr = (uintptr_t)buf;
+//	data.length = size;
+//	shm_fd = ioctl(fd, TEE_IOC_SHM_REGISTER, &data);
+//	if (shm_fd < 0)
+//		return -1;
+//	*id = data.id;
+//	return shm_fd;
+//}
+
+//TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *ctx)
+//{
+//  char devname[PATH_MAX];
+//  int fd;
+//  size_t n;
+//
+//  if (!ctx)
+//    return TEEC_ERROR_BAD_PARAMETERS;
+//
+//  for (n = 0; n < TEEC_MAX_DEV_SEQ; n++) {
+//    uint32_t gen_caps;
+//
+//    snprintf(devname, sizeof(devname), "/dev/tee%zu", n);
+//    fd = teec_open_dev(devname, name, &gen_caps);
+//    if (fd >= 0) {
+//      ctx->fd = fd;
+//      ctx->reg_mem = gen_caps & TEE_GEN_CAP_REG_MEM;
+//      return TEEC_SUCCESS;
+//    }
+//  }
+//
+//  return TEEC_ERROR_ITEM_NOT_FOUND;
+//}
+
+// Temporary defenition
+#define TEEC_MAX_DEV_SEQ 1
+
+TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *ctx)
+{
+  char devname[PATH_MAX];
+  int fd;
+  size_t n;
+
+  if (!ctx)
+    return TEEC_ERROR_BAD_PARAMETERS;
+
+  for (n = 0; n < TEEC_MAX_DEV_SEQ; n++) {
+    uint32_t gen_caps;
+
+//    snprintf(devname, sizeof(devname), "/dev/tee%zu", n);
+    fd = 1; //teec_open_dev(devname, name, &gen_caps);
+    if (fd >= 0) {
+      ctx->fd = fd;
+      ctx->reg_mem = TEE_GEN_CAP_GP | TEE_GEN_CAP_REG_MEM;
+//      ctx->reg_mem = gen_caps & TEE_GEN_CAP_REG_MEM;
+      return TEEC_SUCCESS;
+    }
+  }
+
+  return TEEC_ERROR_ITEM_NOT_FOUND;
+}
+
+void TEEC_FinalizeContext(TEEC_Context *ctx)
+{
+	if (ctx);
+//		close(ctx->fd);
+}
+
+//
+//static TEEC_Result teec_pre_process_tmpref(TEEC_Context *ctx,
+//			uint32_t param_type, TEEC_TempMemoryReference *tmpref,
+//			struct tee_ioctl_param *param,
+//			TEEC_SharedMemory *shm)
+//{
+//	TEEC_Result res;
+//
+//	switch (param_type) {
+//	case TEEC_MEMREF_TEMP_INPUT:
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
+//		shm->flags = TEEC_MEM_INPUT;
+//		break;
+//	case TEEC_MEMREF_TEMP_OUTPUT:
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+//		shm->flags = TEEC_MEM_OUTPUT;
+//		break;
+//	case TEEC_MEMREF_TEMP_INOUT:
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT;
+//		shm->flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
+//		break;
+//	default:
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//	}
+//	shm->size = tmpref->size;
+//
+//	res = TEEC_AllocateSharedMemory(ctx, shm);
+//	if (res != TEEC_SUCCESS)
+//		return res;
+//
+//	memcpy(shm->buffer, tmpref->buffer, tmpref->size);
+//	param->u.memref.size = tmpref->size;
+//	param->u.memref.shm_id = shm->id;
+//	return TEEC_SUCCESS;
+//}
+
+//static TEEC_Result teec_pre_process_whole(
+//			TEEC_RegisteredMemoryReference *memref,
+//			struct tee_ioctl_param *param)
+//{
+//	const uint32_t inout = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
+//	uint32_t flags = memref->parent->flags & inout;
+//	TEEC_SharedMemory *shm;
+//
+//	if (flags == inout)
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT;
+//	else if (flags & TEEC_MEM_INPUT)
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
+//	else if (flags & TEEC_MEM_OUTPUT)
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+//	else
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	shm = memref->parent;
+//	/*
+//	 * We're using a shadow buffer in this reference, copy the real buffer
+//	 * into the shadow buffer if needed. We'll copy it back once we've
+//	 * returned from the call to secure world.
+//	 */
+//	if (shm->shadow_buffer && (flags & TEEC_MEM_INPUT))
+//		memcpy(shm->shadow_buffer, shm->buffer, shm->size);
+//
+//	param->u.memref.shm_id = shm->id;
+//	param->u.memref.size = shm->size;
+//	return TEEC_SUCCESS;
+//}
+//
+//static TEEC_Result teec_pre_process_partial(uint32_t param_type,
+//			TEEC_RegisteredMemoryReference *memref,
+//			struct tee_ioctl_param *param)
+//{
+//	uint32_t req_shm_flags;
+//	TEEC_SharedMemory *shm;
+//
+//	switch (param_type) {
+//	case TEEC_MEMREF_PARTIAL_INPUT:
+//		req_shm_flags = TEEC_MEM_INPUT;
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
+//		break;
+//	case TEEC_MEMREF_PARTIAL_OUTPUT:
+//		req_shm_flags = TEEC_MEM_OUTPUT;
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+//		break;
+//	case TEEC_MEMREF_PARTIAL_INOUT:
+//		req_shm_flags = TEEC_MEM_OUTPUT | TEEC_MEM_INPUT;
+//		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT;
+//		break;
+//	default:
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//	}
+//
+//	shm = memref->parent;
+//
+//	if ((shm->flags & req_shm_flags) != req_shm_flags)
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	/*
+//	 * We're using a shadow buffer in this reference, copy the real buffer
+//	 * into the shadow buffer if needed. We'll copy it back once we've
+//	 * returned from the call to secure world.
+//	 */
+//	if (shm->shadow_buffer && param_type != TEEC_MEMREF_PARTIAL_OUTPUT)
+//		memcpy((char *)shm->shadow_buffer + memref->offset,
+//		       (char *)shm->buffer + memref->offset, memref->size);
+//
+//	param->u.memref.shm_id = shm->id;
+//	param->u.memref.shm_offs = memref->offset;
+//	param->u.memref.size = memref->size;
+//	return TEEC_SUCCESS;
+//}
+//
+static TEEC_Result teec_pre_process_operation(TEEC_Context *ctx,
+			TEEC_Operation *operation,
+			struct tee_ioctl_param *params,
+			TEEC_SharedMemory *shms)
+{
+	TEEC_Result res;
+	size_t n;
+
+	memset(shms, 0, sizeof(TEEC_SharedMemory) *
+			TEEC_CONFIG_PAYLOAD_REF_COUNT);
+	if (!operation) {
+		memset(params, 0, sizeof(struct tee_ioctl_param) *
+				  TEEC_CONFIG_PAYLOAD_REF_COUNT);
+		return TEEC_SUCCESS;
+	}
+
+	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++) {
+		uint32_t param_type;
+
+		param_type = TEEC_PARAM_TYPE_GET(operation->paramTypes, n);
+		switch (param_type) {
+		case TEEC_NONE:
+			params[n].attr = param_type;
+			break;
+		case TEEC_VALUE_INPUT:
+		case TEEC_VALUE_OUTPUT:
+		case TEEC_VALUE_INOUT:
+			params[n].attr = param_type;
+			params[n].u.value.a = operation->params[n].value.a;
+			params[n].u.value.b = operation->params[n].value.b;
+			break;
+		case TEEC_MEMREF_TEMP_INPUT:
+		case TEEC_MEMREF_TEMP_OUTPUT:
+		case TEEC_MEMREF_TEMP_INOUT:
+//			res = teec_pre_process_tmpref(ctx, param_type,
+//				&operation->params[n].tmpref, params + n,
+//				shms + n);
+//			if (res != TEEC_SUCCESS)
+//				return res;
+			break;
+		case TEEC_MEMREF_WHOLE:
+//			res = teec_pre_process_whole(
+//					&operation->params[n].memref,
+//					params + n);
+//			if (res != TEEC_SUCCESS)
+//				return res;
+			break;
+		case TEEC_MEMREF_PARTIAL_INPUT:
+		case TEEC_MEMREF_PARTIAL_OUTPUT:
+		case TEEC_MEMREF_PARTIAL_INOUT:
+//			res = teec_pre_process_partial(param_type,
+//				&operation->params[n].memref, params + n);
+//			if (res != TEEC_SUCCESS)
+//				return res;
+			break;
+		default:
+			return TEEC_ERROR_BAD_PARAMETERS;
+		}
+	}
+
+	return TEEC_SUCCESS;
+}
+
+//static void teec_post_process_tmpref(uint32_t param_type,
+//			TEEC_TempMemoryReference *tmpref,
+//			struct tee_ioctl_param *param,
+//			TEEC_SharedMemory *shm)
+//{
+//	if (param_type != TEEC_MEMREF_TEMP_INPUT) {
+//		if (param->u.memref.size <= tmpref->size && tmpref->buffer)
+//			memcpy(tmpref->buffer, shm->buffer,
+//			       param->u.memref.size);
+//
+//		tmpref->size = param->u.memref.size;
+//	}
+//}
+//
+//static void teec_post_process_whole(TEEC_RegisteredMemoryReference *memref,
+//			struct tee_ioctl_param *param)
+//{
+//	TEEC_SharedMemory *shm = memref->parent;
+//
+//	if (shm->flags & TEEC_MEM_OUTPUT) {
+//
+//		/*
+//		 * We're using a shadow buffer in this reference, copy back
+//		 * the shadow buffer into the real buffer now that we've
+//		 * returned from secure world.
+//		 */
+//		if (shm->shadow_buffer && param->u.memref.size <= shm->size)
+//			memcpy(shm->buffer, shm->shadow_buffer,
+//			       param->u.memref.size);
+//
+//		memref->size = param->u.memref.size;
+//	}
+//}
+//
+//static void teec_post_process_partial(uint32_t param_type,
+//			TEEC_RegisteredMemoryReference *memref,
+//			struct tee_ioctl_param *param)
+//{
+//	if (param_type != TEEC_MEMREF_PARTIAL_INPUT) {
+//		TEEC_SharedMemory *shm = memref->parent;
+//
+//		/*
+//		 * We're using a shadow buffer in this reference, copy back
+//		 * the shadow buffer into the real buffer now that we've
+//		 * returned from secure world.
+//		 */
+//		if (shm->shadow_buffer && param->u.memref.size <= memref->size)
+//			memcpy((char *)shm->buffer + memref->offset,
+//			       (char *)shm->shadow_buffer + memref->offset,
+//			       param->u.memref.size);
+//
+//		memref->size = param->u.memref.size;
+//	}
+//}
+
+static void teec_post_process_operation(TEEC_Operation *operation,
+			struct tee_ioctl_param *params,
+			TEEC_SharedMemory *shms)
+{
+	size_t n;
+
+	if (!operation)
+		return;
+
+	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++) {
+		uint32_t param_type;
+
+		param_type = TEEC_PARAM_TYPE_GET(operation->paramTypes, n);
+		switch (param_type) {
+		case TEEC_VALUE_INPUT:
+			break;
+		case TEEC_VALUE_OUTPUT:
+		case TEEC_VALUE_INOUT:
+			operation->params[n].value.a = params[n].u.value.a;
+			operation->params[n].value.b = params[n].u.value.b;
+			break;
+		case TEEC_MEMREF_TEMP_INPUT:
+		case TEEC_MEMREF_TEMP_OUTPUT:
+		case TEEC_MEMREF_TEMP_INOUT:
+//			teec_post_process_tmpref(param_type,
+//				&operation->params[n].tmpref, params + n,
+//				shms + n);
+			break;
+		case TEEC_MEMREF_WHOLE:
+//			teec_post_process_whole(&operation->params[n].memref,
+//						params + n);
+			break;
+		case TEEC_MEMREF_PARTIAL_INPUT:
+		case TEEC_MEMREF_PARTIAL_OUTPUT:
+		case TEEC_MEMREF_PARTIAL_INOUT:
+//			teec_post_process_partial(param_type,
+//				&operation->params[n].memref, params + n);
+		default:
+			break;
+		}
+	}
+}
+
+//static void teec_free_temp_refs(TEEC_Operation *operation,
+//			TEEC_SharedMemory *shms)
+//{
+//	size_t n;
+//
+//	if (!operation)
+//		return;
+//
+//	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++) {
+//		switch (TEEC_PARAM_TYPE_GET(operation->paramTypes, n)) {
+//		case TEEC_MEMREF_TEMP_INPUT:
+//		case TEEC_MEMREF_TEMP_OUTPUT:
+//		case TEEC_MEMREF_TEMP_INOUT:
+//			TEEC_ReleaseSharedMemory(shms + n);
+//			break;
+//		default:
+//			break;
+//		}
+//	}
+//}
+//
+//static TEEC_Result ioctl_errno_to_res(int err)
+//{
+//	switch (err) {
+//	case ENOMEM:
+//		return TEEC_ERROR_OUT_OF_MEMORY;
+//	default:
+//		return TEEC_ERROR_GENERIC;
+//	}
+//}
+//
+static void uuid_to_octets(uint8_t d[TEE_IOCTL_UUID_LEN], const TEEC_UUID *s)
+{
+	d[0] = s->timeLow >> 24;
+	d[1] = s->timeLow >> 16;
+	d[2] = s->timeLow >> 8;
+	d[3] = s->timeLow;
+	d[4] = s->timeMid >> 8;
+	d[5] = s->timeMid;
+	d[6] = s->timeHiAndVersion >> 8;
+	d[7] = s->timeHiAndVersion;
+	memcpy(d + 8, s->clockSeqAndNode, sizeof(s->clockSeqAndNode));
+}
+
+//TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
+//			const TEEC_UUID *destination,
+//			uint32_t connection_method, const void *connection_data,
+//			TEEC_Operation *operation, uint32_t *ret_origin)
+//{
+//	uint64_t buf[(sizeof(struct tee_ioctl_open_session_arg) +
+//			TEEC_CONFIG_PAYLOAD_REF_COUNT *
+//				sizeof(struct tee_ioctl_param)) /
+//			sizeof(uint64_t)] = { 0 };
+//	struct tee_ioctl_buf_data buf_data;
+//	struct tee_ioctl_open_session_arg *arg;
+//	struct tee_ioctl_param *params;
+//	TEEC_Result res;
+//	uint32_t eorig;
+//	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+//	int rc;
+//
+//	(void)&connection_data;
+//
+//	if (!ctx || !session) {
+//		eorig = TEEC_ORIGIN_API;
+//		res = TEEC_ERROR_BAD_PARAMETERS;
+//		goto out;
+//	}
+//
+//	buf_data.buf_ptr = (uintptr_t)buf;
+//	buf_data.buf_len = sizeof(buf);
+//
+//	arg = (struct tee_ioctl_open_session_arg *)buf;
+//	arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
+//	params = (struct tee_ioctl_param *)(arg + 1);
+//
+//	uuid_to_octets(arg->uuid, destination);
+//	arg->clnt_login = connection_method;
+//
+//	res = teec_pre_process_operation(ctx, operation, params, shm);
+//	if (res != TEEC_SUCCESS) {
+//		eorig = TEEC_ORIGIN_API;
+//		goto out_free_temp_refs;
+//	}
+//
+//	rc = ioctl(ctx->fd, TEE_IOC_OPEN_SESSION, &buf_data);
+//	if (rc) {
+//		EMSG("TEE_IOC_OPEN_SESSION failed");
+//		eorig = TEEC_ORIGIN_COMMS;
+//		res = ioctl_errno_to_res(errno);
+//		goto out_free_temp_refs;
+//	}
+//	res = arg->ret;
+//	eorig = arg->ret_origin;
+//	if (res == TEEC_SUCCESS) {
+//		session->ctx = ctx;
+//		session->session_id = arg->session;
+//	}
+//	teec_post_process_operation(operation, params, shm);
+//
+//out_free_temp_refs:
+//	teec_free_temp_refs(operation, shm);
+//out:
+//	if (ret_origin)
+//		*ret_origin = eorig;
+//	return res;
+//}
+
+TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
+      const TEEC_UUID *destination,
+      uint32_t connection_method, const void *connection_data,
+      TEEC_Operation *operation, uint32_t *ret_origin)
+{
+  uint32_t buf[(sizeof(struct tee_ioctl_open_session_arg) +
+      TEEC_CONFIG_PAYLOAD_REF_COUNT *
+        sizeof(struct tee_ioctl_param)) /
+      sizeof(uint32_t)] = { 0 };
+  struct tee_ioctl_buf_data buf_data;
+  struct tee_ioctl_open_session_arg *arg;
+  struct tee_ioctl_param *params;
+  TEEC_Result res;
+  uint32_t eorig;
+  TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+  int rc;
+
+  (void)&connection_data;
+
+  if (!ctx || !session) {
+    eorig = TEEC_ORIGIN_API;
+    res = TEEC_ERROR_BAD_PARAMETERS;
+    goto out;
+  }
+
+  buf_data.buf_ptr = (uintptr_t)buf;
+  buf_data.buf_len = sizeof(buf);
+
+  arg = (struct tee_ioctl_open_session_arg *)buf;
+  arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
+  params = (struct tee_ioctl_param *)(arg + 1);
+
+  uuid_to_octets(arg->uuid, destination);
+  arg->clnt_login = connection_method;
+
+  res = teec_pre_process_operation(ctx, operation, params, shm);
+  if (res != TEEC_SUCCESS) {
+    eorig = TEEC_ORIGIN_API;
+    goto out_free_temp_refs;
+  }
+
+  rc = ioctl(/*ctx->fd,*/ TEE_IOC_OPEN_SESSION, &buf_data);
+  if (rc) {
+    printf("TEE_IOC_OPEN_SESSION failed\n");
+//    EMSG("TEE_IOC_OPEN_SESSION failed");
+    eorig = TEEC_ORIGIN_COMMS;
+//    res = ioctl_errno_to_res(errno);
+    goto out_free_temp_refs;
+  }
+  res = arg->ret;
+  eorig = arg->ret_origin;
+  if (res == TEEC_SUCCESS) {
+    session->ctx = ctx;
+    session->session_id = arg->session;
+  }
+  teec_post_process_operation(operation, params, shm);
+
+out_free_temp_refs:
+//  teec_free_temp_refs(operation, shm);
+out:
+  if (ret_origin)
+    *ret_origin = eorig;
+  return res;
+}
+
+//void TEEC_CloseSession(TEEC_Session *session)
+//{
+//	struct tee_ioctl_close_session_arg arg;
+//
+//	if (!session)
+//		return;
+//
+//	arg.session = session->session_id;
+//	if (ioctl(session->ctx->fd, TEE_IOC_CLOSE_SESSION, &arg))
+//		EMSG("Failed to close session 0x%x", session->session_id);
+//}
+
+void TEEC_CloseSession(TEEC_Session *session)
+{
+  struct tee_ioctl_close_session_arg arg;
+
+  if (!session)
+    return;
+
+  arg.session = session->session_id;
+  if (ioctl(/*session->ctx->fd,*/ TEE_IOC_CLOSE_SESSION, &arg))
+    printf("Failed to close session 0x%x\n", session->session_id);
+  else
+    printf("Session successfully closed 0x%x\n", session->session_id);
+  session->session_id = 0;
+}
+
+//TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
+//      TEEC_Operation *operation, uint32_t *error_origin)
+//{
+//  uint64_t buf[(sizeof(struct tee_ioctl_invoke_arg) +
+//      TEEC_CONFIG_PAYLOAD_REF_COUNT *
+//        sizeof(struct tee_ioctl_param)) /
+//      sizeof(uint64_t)] = { 0 };
+//  struct tee_ioctl_buf_data buf_data;
+//  struct tee_ioctl_invoke_arg *arg;
+//  struct tee_ioctl_param *params;
+//  TEEC_Result res;
+//  uint32_t eorig;
+//  TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+//  int rc;
+//
+//  if (!session) {
+//    eorig = TEEC_ORIGIN_API;
+//    res = TEEC_ERROR_BAD_PARAMETERS;
+//    goto out;
+//  }
+//
+//  bm_timestamp();
+//
+//  buf_data.buf_ptr = (uintptr_t)buf;
+//  buf_data.buf_len = sizeof(buf);
+//
+//  arg = (struct tee_ioctl_invoke_arg *)buf;
+//  arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
+//  params = (struct tee_ioctl_param *)(arg + 1);
+//
+//  arg->session = session->session_id;
+//  arg->func = cmd_id;
+//
+//  if (operation) {
+//    teec_mutex_lock(&teec_mutex);
+//    operation->session = session;
+//    teec_mutex_unlock(&teec_mutex);
+//  }
+//
+//  res = teec_pre_process_operation(session->ctx, operation, params, shm);
+//  if (res != TEEC_SUCCESS) {
+//    eorig = TEEC_ORIGIN_API;
+//    goto out_free_temp_refs;
+//  }
+//
+//  rc = ioctl(session->ctx->fd, TEE_IOC_INVOKE, &buf_data);
+//  if (rc) {
+//    EMSG("TEE_IOC_INVOKE failed");
+//    eorig = TEEC_ORIGIN_COMMS;
+//    res = ioctl_errno_to_res(errno);
+//    goto out_free_temp_refs;
+//  }
+//
+//  res = arg->ret;
+//  eorig = arg->ret_origin;
+//  teec_post_process_operation(operation, params, shm);
+//
+//  bm_timestamp();
+//
+//out_free_temp_refs:
+//  teec_free_temp_refs(operation, shm);
+//out:
+//  if (error_origin)
+//    *error_origin = eorig;
+//  return res;
+//}
+//
+TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
+      TEEC_Operation *operation, uint32_t *error_origin)
+{
+  uint64_t buf[(sizeof(struct tee_ioctl_invoke_arg) +
+      TEEC_CONFIG_PAYLOAD_REF_COUNT *
+        sizeof(struct tee_ioctl_param)) /
+      sizeof(uint64_t)] = { 0 };
+  struct tee_ioctl_buf_data buf_data;
+  struct tee_ioctl_invoke_arg *arg;
+  struct tee_ioctl_param *params;
+  TEEC_Result res;
+  uint32_t eorig;
+  TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+  int rc;
+
+  if (!session) {
+    eorig = TEEC_ORIGIN_API;
+    res = TEEC_ERROR_BAD_PARAMETERS;
+    goto out;
+  }
+
+//  bm_timestamp();
+
+  buf_data.buf_ptr = (uintptr_t)buf;
+  buf_data.buf_len = sizeof(buf);
+
+  arg = (struct tee_ioctl_invoke_arg *)buf;
+  arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
+  params = (struct tee_ioctl_param *)(arg + 1);
+
+  arg->session = session->session_id;
+  arg->func = cmd_id;
+
+  if (operation) {
+//    teec_mutex_lock(&teec_mutex);
+    operation->session = session;
+//    teec_mutex_unlock(&teec_mutex);
+  }
+
+  res = teec_pre_process_operation(session->ctx, operation, params, shm);
+  if (res != TEEC_SUCCESS) {
+    eorig = TEEC_ORIGIN_API;
+    goto out_free_temp_refs;
+  }
+
+  rc = ioctl(/*session->ctx->fd,*/ TEE_IOC_INVOKE, &buf_data);
+  if (rc) {
+//    EMSG("TEE_IOC_INVOKE failed");
+    eorig = TEEC_ORIGIN_COMMS;
+//    res = ioctl_errno_to_res(errno);
+    goto out_free_temp_refs;
+  }
+
+  res = arg->ret;
+  eorig = arg->ret_origin;
+  teec_post_process_operation(operation, params, shm);
+
+//  bm_timestamp();
+
+out_free_temp_refs:
+//  teec_free_temp_refs(operation, shm);
+out:
+  if (error_origin)
+    *error_origin = eorig;
+  return res;
+}
+
+//void TEEC_RequestCancellation(TEEC_Operation *operation)
+//{
+//	struct tee_ioctl_cancel_arg arg;
+//	TEEC_Session *session;
+//
+//	if (!operation)
+//		return;
+//
+//	teec_mutex_lock(&teec_mutex);
+//	session = operation->session;
+//	teec_mutex_unlock(&teec_mutex);
+//
+//	if (!session)
+//		return;
+//
+//	arg.session = session->session_id;
+//	arg.cancel_id = 0;
+//
+//	if (ioctl(session->ctx->fd, TEE_IOC_CANCEL, &arg))
+//		EMSG("TEE_IOC_CANCEL: %s", strerror(errno));
+//}
+//
+//TEEC_Result TEEC_RegisterSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
+//{
+//	int fd;
+//	size_t s;
+//
+//	if (!ctx || !shm)
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	if (!shm->flags || (shm->flags & ~(TEEC_MEM_INPUT | TEEC_MEM_OUTPUT)))
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	s = shm->size;
+//	if (!s)
+//		s = 8;
+//	if (ctx->reg_mem) {
+//		fd = teec_shm_register(ctx->fd, shm->buffer, s, &shm->id);
+//		if (fd < 0)
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//		shm->registered_fd = fd;
+//		shm->shadow_buffer = NULL;
+//	} else {
+//		fd = teec_shm_alloc(ctx->fd, s, &shm->id);
+//		if (fd < 0)
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//
+//		shm->shadow_buffer = mmap(NULL, s, PROT_READ | PROT_WRITE,
+//					  MAP_SHARED, fd, 0);
+//		close(fd);
+//		if (shm->shadow_buffer == (void *)MAP_FAILED) {
+//			shm->id = -1;
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//		}
+//		shm->registered_fd = -1;
+//	}
+//
+//	shm->alloced_size = s;
+//	shm->buffer_allocated = false;
+//	return TEEC_SUCCESS;
+//}
+//
+//TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *ctx,
+//						    TEEC_SharedMemory *shm,
+//						    int fd)
+//{
+//	struct tee_ioctl_shm_register_fd_data data;
+//	int rfd;
+//
+//	if (!ctx || !shm || fd < 0)
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	if (!shm->flags || (shm->flags & ~(TEEC_MEM_INPUT | TEEC_MEM_OUTPUT)))
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	memset(&data, 0, sizeof(data));
+//	data.fd = fd;
+//	rfd = ioctl(ctx->fd, TEE_IOC_SHM_REGISTER_FD, &data);
+//	if (rfd < 0)
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	shm->buffer = NULL;
+//	shm->shadow_buffer = NULL;
+//	shm->registered_fd = rfd;
+//	shm->id = data.id;
+//	shm->size = data.size;
+//	return TEEC_SUCCESS;
+//}
+//
+//TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
+//{
+//	int fd;
+//	size_t s;
+//
+//	if (!ctx || !shm)
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	if (!shm->flags || (shm->flags & ~(TEEC_MEM_INPUT | TEEC_MEM_OUTPUT)))
+//		return TEEC_ERROR_BAD_PARAMETERS;
+//
+//	s = shm->size;
+//	if (!s)
+//		s = 8;
+//
+//	if (ctx->reg_mem) {
+//		shm->buffer = malloc(s);
+//		if (!shm->buffer)
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//
+//		fd = teec_shm_register(ctx->fd, shm->buffer, s, &shm->id);
+//		if (fd < 0) {
+//			free(shm->buffer);
+//			shm->buffer = NULL;
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//		}
+//		shm->registered_fd = fd;
+//	} else {
+//		fd = teec_shm_alloc(ctx->fd, s, &shm->id);
+//		if (fd < 0)
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//
+//		shm->buffer = mmap(NULL, s, PROT_READ | PROT_WRITE,
+//				   MAP_SHARED, fd, 0);
+//		close(fd);
+//		if (shm->buffer == (void *)MAP_FAILED) {
+//			shm->id = -1;
+//			return TEEC_ERROR_OUT_OF_MEMORY;
+//		}
+//		shm->registered_fd = -1;
+//	}
+//
+//	shm->shadow_buffer = NULL;
+//	shm->alloced_size = s;
+//	shm->buffer_allocated = true;
+//	return TEEC_SUCCESS;
+//}
+//
+//void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *shm)
+//{
+//	if (!shm || shm->id == -1)
+//		return;
+//
+//	if (shm->shadow_buffer)
+//		munmap(shm->shadow_buffer, shm->alloced_size);
+//	else if (shm->buffer) {
+//		if (shm->registered_fd >= 0) {
+//			if (shm->buffer_allocated)
+//				free(shm->buffer);
+//			close(shm->registered_fd);
+//		} else
+//			munmap(shm->buffer, shm->alloced_size);
+//	} else if (shm->registered_fd >= 0)
+//		close(shm->registered_fd);
+//
+//	shm->id = -1;
+//	shm->shadow_buffer = NULL;
+//	shm->buffer = NULL;
+//	shm->registered_fd = -1;
+//	shm->buffer_allocated = false;
+//}

--- a/tee_client/public/tee_client_api.h
+++ b/tee_client/public/tee_client_api.h
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TEE_CLIENT_API_H
+#define TEE_CLIENT_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <limits.h>
+
+/*
+ * Defines the number of available memory references in an open session or
+ * invoke command operation payload.
+ */
+#define TEEC_CONFIG_PAYLOAD_REF_COUNT 4
+
+/**
+ * Defines the maximum size of a single shared memory block, in bytes, of both
+ * API allocated and API registered memory. There is no good value to put here
+ * (limits depend on specific config used), so this define does not provide any
+ * restriction in this implementation.
+ */
+#define TEEC_CONFIG_SHAREDMEM_MAX_SIZE ULONG_MAX
+
+/**
+ * Flag constants indicating the type of parameters encoded inside the
+ * operation payload (TEEC_Operation), Type is uint32_t.
+ *
+ * TEEC_NONE                   The Parameter is not used
+ *
+ * TEEC_VALUE_INPUT            The Parameter is a TEEC_Value tagged as input.
+ *
+ * TEEC_VALUE_OUTPUT           The Parameter is a TEEC_Value tagged as output.
+ *
+ * TEEC_VALUE_INOUT            The Parameter is a TEEC_Value tagged as both as
+ *                             input and output, i.e., for which both the
+ *                             behaviors of TEEC_VALUE_INPUT and
+ *                             TEEC_VALUE_OUTPUT apply.
+ *
+ * TEEC_MEMREF_TEMP_INPUT      The Parameter is a TEEC_TempMemoryReference
+ *                             describing a region of memory which needs to be
+ *                             temporarily registered for the duration of the
+ *                             Operation and is tagged as input.
+ *
+ * TEEC_MEMREF_TEMP_OUTPUT     Same as TEEC_MEMREF_TEMP_INPUT, but the Memory
+ *                             Reference is tagged as output. The
+ *                             Implementation may update the size field to
+ *                             reflect the required output size in some use
+ *                             cases.
+ *
+ * TEEC_MEMREF_TEMP_INOUT      A Temporary Memory Reference tagged as both
+ *                             input and output, i.e., for which both the
+ *                             behaviors of TEEC_MEMREF_TEMP_INPUT and
+ *                             TEEC_MEMREF_TEMP_OUTPUT apply.
+ *
+ * TEEC_MEMREF_WHOLE           The Parameter is a Registered Memory Reference
+ *                             that refers to the entirety of its parent Shared
+ *                             Memory block. The parameter structure is a
+ *                             TEEC_MemoryReference. In this structure, the
+ *                             Implementation MUST read only the parent field
+ *                             and MAY update the size field when the operation
+ *                             completes.
+ *
+ * TEEC_MEMREF_PARTIAL_INPUT   A Registered Memory Reference structure that
+ *                             refers to a partial region of its parent Shared
+ *                             Memory block and is tagged as input.
+ *
+ * TEEC_MEMREF_PARTIAL_OUTPUT  Registered Memory Reference structure that
+ *                             refers to a partial region of its parent Shared
+ *                             Memory block and is tagged as output.
+ *
+ * TEEC_MEMREF_PARTIAL_INOUT   The Registered Memory Reference structure that
+ *                             refers to a partial region of its parent Shared
+ *                             Memory block and is tagged as both input and
+ *                             output, i.e., for which both the behaviors of
+ *                             TEEC_MEMREF_PARTIAL_INPUT and
+ *                             TEEC_MEMREF_PARTIAL_OUTPUT apply.
+ */
+#define TEEC_NONE                   0x00000000
+#define TEEC_VALUE_INPUT            0x00000001
+#define TEEC_VALUE_OUTPUT           0x00000002
+#define TEEC_VALUE_INOUT            0x00000003
+#define TEEC_MEMREF_TEMP_INPUT      0x00000005
+#define TEEC_MEMREF_TEMP_OUTPUT     0x00000006
+#define TEEC_MEMREF_TEMP_INOUT      0x00000007
+#define TEEC_MEMREF_WHOLE           0x0000000C
+#define TEEC_MEMREF_PARTIAL_INPUT   0x0000000D
+#define TEEC_MEMREF_PARTIAL_OUTPUT  0x0000000E
+#define TEEC_MEMREF_PARTIAL_INOUT   0x0000000F
+
+/**
+ * Flag constants indicating the data transfer direction of memory in
+ * TEEC_Parameter. TEEC_MEM_INPUT signifies data transfer direction from the
+ * client application to the TEE. TEEC_MEM_OUTPUT signifies data transfer
+ * direction from the TEE to the client application. Type is uint32_t.
+ *
+ * TEEC_MEM_INPUT   The Shared Memory can carry data from the client
+ *                  application to the Trusted Application.
+ * TEEC_MEM_OUTPUT  The Shared Memory can carry data from the Trusted
+ *                  Application to the client application.
+ */
+#define TEEC_MEM_INPUT   0x00000001
+#define TEEC_MEM_OUTPUT  0x00000002
+
+/**
+ * Return values. Type is TEEC_Result
+ *
+ * TEEC_SUCCESS                 The operation was successful.
+ * TEEC_ERROR_GENERIC           Non-specific cause.
+ * TEEC_ERROR_ACCESS_DENIED     Access privileges are not sufficient.
+ * TEEC_ERROR_CANCEL            The operation was canceled.
+ * TEEC_ERROR_ACCESS_CONFLICT   Concurrent accesses caused conflict.
+ * TEEC_ERROR_EXCESS_DATA       Too much data for the requested operation was
+ *                              passed.
+ * TEEC_ERROR_BAD_FORMAT        Input data was of invalid format.
+ * TEEC_ERROR_BAD_PARAMETERS    Input parameters were invalid.
+ * TEEC_ERROR_BAD_STATE         Operation is not valid in the current state.
+ * TEEC_ERROR_ITEM_NOT_FOUND    The requested data item is not found.
+ * TEEC_ERROR_NOT_IMPLEMENTED   The requested operation should exist but is not
+ *                              yet implemented.
+ * TEEC_ERROR_NOT_SUPPORTED     The requested operation is valid but is not
+ *                              supported in this implementation.
+ * TEEC_ERROR_NO_DATA           Expected data was missing.
+ * TEEC_ERROR_OUT_OF_MEMORY     System ran out of resources.
+ * TEEC_ERROR_BUSY              The system is busy working on something else.
+ * TEEC_ERROR_COMMUNICATION     Communication with a remote party failed.
+ * TEEC_ERROR_SECURITY          A security fault was detected.
+ * TEEC_ERROR_SHORT_BUFFER      The supplied buffer is too short for the
+ *                              generated output.
+ * TEEC_ERROR_TARGET_DEAD       Trusted Application has panicked
+ *                              during the operation.
+ */
+
+/**
+ *  Standard defined error codes.
+ */
+#define TEEC_SUCCESS                0x00000000
+#define TEEC_ERROR_GENERIC          0xFFFF0000
+#define TEEC_ERROR_ACCESS_DENIED    0xFFFF0001
+#define TEEC_ERROR_CANCEL           0xFFFF0002
+#define TEEC_ERROR_ACCESS_CONFLICT  0xFFFF0003
+#define TEEC_ERROR_EXCESS_DATA      0xFFFF0004
+#define TEEC_ERROR_BAD_FORMAT       0xFFFF0005
+#define TEEC_ERROR_BAD_PARAMETERS   0xFFFF0006
+#define TEEC_ERROR_BAD_STATE        0xFFFF0007
+#define TEEC_ERROR_ITEM_NOT_FOUND   0xFFFF0008
+#define TEEC_ERROR_NOT_IMPLEMENTED  0xFFFF0009
+#define TEEC_ERROR_NOT_SUPPORTED    0xFFFF000A
+#define TEEC_ERROR_NO_DATA          0xFFFF000B
+#define TEEC_ERROR_OUT_OF_MEMORY    0xFFFF000C
+#define TEEC_ERROR_BUSY             0xFFFF000D
+#define TEEC_ERROR_COMMUNICATION    0xFFFF000E
+#define TEEC_ERROR_SECURITY         0xFFFF000F
+#define TEEC_ERROR_SHORT_BUFFER     0xFFFF0010
+#define TEEC_ERROR_EXTERNAL_CANCEL  0xFFFF0011
+#define TEEC_ERROR_TARGET_DEAD      0xFFFF3024
+
+/**
+ * Function error origins, of type TEEC_ErrorOrigin. These indicate where in
+ * the software stack a particular return value originates from.
+ *
+ * TEEC_ORIGIN_API          The error originated within the TEE Client API
+ *                          implementation.
+ * TEEC_ORIGIN_COMMS        The error originated within the underlying
+ *                          communications stack linking the rich OS with
+ *                          the TEE.
+ * TEEC_ORIGIN_TEE          The error originated within the common TEE code.
+ * TEEC_ORIGIN_TRUSTED_APP  The error originated within the Trusted Application
+ *                          code.
+ */
+#define TEEC_ORIGIN_API          0x00000001
+#define TEEC_ORIGIN_COMMS        0x00000002
+#define TEEC_ORIGIN_TEE          0x00000003
+#define TEEC_ORIGIN_TRUSTED_APP  0x00000004
+
+/**
+ * Session login methods, for use in TEEC_OpenSession() as parameter
+ * connectionMethod. Type is uint32_t.
+ *
+ * TEEC_LOGIN_PUBLIC    	 No login data is provided.
+ * TEEC_LOGIN_USER         	Login data about the user running the Client
+ *                         	Application process is provided.
+ * TEEC_LOGIN_GROUP        	Login data about the group running the Client
+ *                         	Application process is provided.
+ * TEEC_LOGIN_APPLICATION  	Login data about the running Client Application
+ *                         	itself is provided.
+ * TEEC_LOGIN_USER_APPLICATION  Login data about the user and the running
+ *                          	Client Application itself is provided.
+ * TEEC_LOGIN_GROUP_APPLICATION Login data about the group and the running
+ *                          	Client Application itself is provided.
+ */
+#define TEEC_LOGIN_PUBLIC       0x00000000
+#define TEEC_LOGIN_USER         0x00000001
+#define TEEC_LOGIN_GROUP        0x00000002
+#define TEEC_LOGIN_APPLICATION  0x00000004
+#define TEEC_LOGIN_USER_APPLICATION  0x00000005
+#define TEEC_LOGIN_GROUP_APPLICATION  0x00000006
+
+/**
+ * Encode the paramTypes according to the supplied types.
+ *
+ * @param p0 The first param type.
+ * @param p1 The second param type.
+ * @param p2 The third param type.
+ * @param p3 The fourth param type.
+ */
+#define TEEC_PARAM_TYPES(p0, p1, p2, p3) \
+	((p0) | ((p1) << 4) | ((p2) << 8) | ((p3) << 12))
+
+/**
+ * Get the i_th param type from the paramType.
+ *
+ * @param p The paramType.
+ * @param i The i-th parameter to get the type for.
+ */
+#define TEEC_PARAM_TYPE_GET(p, i) (((p) >> (i * 4)) & 0xF)
+
+typedef uint32_t TEEC_Result;
+
+/**
+ * struct TEEC_Context - Represents a connection between a client application
+ * and a TEE.
+ */
+typedef struct {
+	/* Implementation defined */
+	int fd;
+	bool reg_mem;
+} TEEC_Context;
+
+/**
+ * This type contains a Universally Unique Resource Identifier (UUID) type as
+ * defined in RFC4122. These UUID values are used to identify Trusted
+ * Applications.
+ */
+typedef struct {
+	uint32_t timeLow;
+	uint16_t timeMid;
+	uint16_t timeHiAndVersion;
+	uint8_t clockSeqAndNode[8];
+} TEEC_UUID;
+
+/**
+ * struct TEEC_SharedMemory - Memory to transfer data between a client
+ * application and trusted code.
+ *
+ * @param buffer      The memory buffer which is to be, or has been, shared
+ *                    with the TEE.
+ * @param size        The size, in bytes, of the memory buffer.
+ * @param flags       Bit-vector which holds properties of buffer.
+ *                    The bit-vector can contain either or both of the
+ *                    TEEC_MEM_INPUT and TEEC_MEM_OUTPUT flags.
+ *
+ * A shared memory block is a region of memory allocated in the context of the
+ * client application memory space that can be used to transfer data between
+ * that client application and a trusted application. The user of this struct
+ * is responsible to populate the buffer pointer.
+ */
+typedef struct {
+	void *buffer;
+	size_t size;
+	uint32_t flags;
+	/*
+	 * Implementation-Defined
+	 */
+	int id;
+	size_t alloced_size;
+	void *shadow_buffer;
+	int registered_fd;
+	bool buffer_allocated;
+} TEEC_SharedMemory;
+
+/**
+ * struct TEEC_TempMemoryReference - Temporary memory to transfer data between
+ * a client application and trusted code, only used for the duration of the
+ * operation.
+ *
+ * @param buffer  The memory buffer which is to be, or has been shared with
+ *                the TEE.
+ * @param size    The size, in bytes, of the memory buffer.
+ *
+ * A memory buffer that is registered temporarily for the duration of the
+ * operation to be called.
+ */
+typedef struct {
+	void *buffer;
+	size_t size;
+} TEEC_TempMemoryReference;
+
+/**
+ * struct TEEC_RegisteredMemoryReference - use a pre-registered or
+ * pre-allocated shared memory block of memory to transfer data between
+ * a client application and trusted code.
+ *
+ * @param parent  Points to a shared memory structure. The memory reference
+ *                may utilize the whole shared memory or only a part of it.
+ *                Must not be NULL
+ *
+ * @param size    The size, in bytes, of the memory buffer.
+ *
+ * @param offset  The offset, in bytes, of the referenced memory region from
+ *                the start of the shared memory block.
+ *
+ */
+typedef struct {
+	TEEC_SharedMemory *parent;
+	size_t size;
+	size_t offset;
+} TEEC_RegisteredMemoryReference;
+
+/**
+ * struct TEEC_Value - Small raw data container
+ *
+ * Instead of allocating a shared memory buffer this structure can be used
+ * to pass small raw data between a client application and trusted code.
+ *
+ * @param a  The first integer value.
+ *
+ * @param b  The second second value.
+ */
+typedef struct {
+	uint32_t a;
+	uint32_t b;
+} TEEC_Value;
+
+/**
+ * union TEEC_Parameter - Memory container to be used when passing data between
+ *                        client application and trusted code.
+ *
+ * Either the client uses a shared memory reference, parts of it or a small raw
+ * data container.
+ *
+ * @param tmpref  A temporary memory reference only valid for the duration
+ *                of the operation.
+ *
+ * @param memref  The entire shared memory or parts of it.
+ *
+ * @param value   The small raw data container to use
+ */
+typedef union {
+	TEEC_TempMemoryReference tmpref;
+	TEEC_RegisteredMemoryReference memref;
+	TEEC_Value value;
+} TEEC_Parameter;
+
+/**
+ * struct TEEC_Session - Represents a connection between a client application
+ * and a trusted application.
+ */
+typedef struct {
+	/* Implementation defined */
+	TEEC_Context *ctx;
+	uint32_t session_id;
+} TEEC_Session;
+
+/**
+ * struct TEEC_Operation - Holds information and memory references used in
+ * TEEC_InvokeCommand().
+ *
+ * @param   started     Client must initialize to zero if it needs to cancel
+ *                      an operation about to be performed.
+ * @param   paramTypes  Type of data passed. Use TEEC_PARAMS_TYPE macro to
+ *                      create the correct flags.
+ *                      0 means TEEC_NONE is passed for all params.
+ * @param   params      Array of parameters of type TEEC_Parameter.
+ * @param   session     Internal pointer to the last session used by
+ *                      TEEC_InvokeCommand with this operation.
+ *
+ */
+typedef struct {
+	uint32_t started;
+	uint32_t paramTypes;
+	TEEC_Parameter params[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+	/* Implementation-Defined */
+	TEEC_Session *session;
+} TEEC_Operation;
+
+/**
+ * TEEC_InitializeContext() - Initializes a context holding connection
+ * information on the specific TEE, designated by the name string.
+
+ * @param name    A zero-terminated string identifying the TEE to connect to.
+ *                If name is set to NULL, the default TEE is connected to. NULL
+ *                is the only supported value in this version of the API
+ *                implementation.
+ *
+ * @param context The context structure which is to be initialized.
+ *
+ * @return TEEC_SUCCESS  The initialization was successful.
+ * @return TEEC_Result   Something failed.
+ */
+TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *context);
+
+/**
+ * TEEC_FinalizeContext() - Destroys a context holding connection information
+ * on the specific TEE.
+ *
+ * This function destroys an initialized TEE context, closing the connection
+ * between the client application and the TEE. This function must only be
+ * called when all sessions related to this TEE context have been closed and
+ * all shared memory blocks have been released.
+ *
+ * @param context       The context to be destroyed.
+ */
+void TEEC_FinalizeContext(TEEC_Context *context);
+
+/**
+ * TEEC_OpenSession() - Opens a new session with the specified trusted
+ *                      application.
+ *
+ * @param context            The initialized TEE context structure in which
+ *                           scope to open the session.
+ * @param session            The session to initialize.
+ * @param destination        A structure identifying the trusted application
+ *                           with which to open a session.
+ *
+ * @param connectionMethod   The connection method to use.
+ * @param connectionData     Any data necessary to connect with the chosen
+ *                           connection method. Not supported, should be set to
+ *                           NULL.
+ * @param operation          An operation structure to use in the session. May
+ *                           be set to NULL to signify no operation structure
+ *                           needed.
+ *
+ * @param returnOrigin       A parameter which will hold the error origin if
+ *                           this function returns any value other than
+ *                           TEEC_SUCCESS.
+ *
+ * @return TEEC_SUCCESS      OpenSession successfully opened a new session.
+ * @return TEEC_Result       Something failed.
+ *
+ */
+TEEC_Result TEEC_OpenSession(TEEC_Context *context,
+			     TEEC_Session *session,
+			     const TEEC_UUID *destination,
+			     uint32_t connectionMethod,
+			     const void *connectionData,
+			     TEEC_Operation *operation,
+			     uint32_t *returnOrigin);
+
+/**
+ * TEEC_CloseSession() - Closes the session which has been opened with the
+ * specific trusted application.
+ *
+ * @param session The opened session to close.
+ */
+void TEEC_CloseSession(TEEC_Session *session);
+
+/**
+ * TEEC_InvokeCommand() - Executes a command in the specified trusted
+ * application.
+ *
+ * @param session        A handle to an open connection to the trusted
+ *                       application.
+ * @param commandID      Identifier of the command in the trusted application
+ *                       to invoke.
+ * @param operation      An operation structure to use in the invoke command.
+ *                       May be set to NULL to signify no operation structure
+ *                       needed.
+ * @param returnOrigin   A parameter which will hold the error origin if this
+ *                       function returns any value other than TEEC_SUCCESS.
+ *
+ * @return TEEC_SUCCESS  OpenSession successfully opened a new session.
+ * @return TEEC_Result   Something failed.
+ */
+TEEC_Result TEEC_InvokeCommand(TEEC_Session *session,
+			       uint32_t commandID,
+			       TEEC_Operation *operation,
+			       uint32_t *returnOrigin);
+
+/**
+ * TEEC_RegisterSharedMemory() - Register a block of existing memory as a
+ * shared block within the scope of the specified context.
+ *
+ * @param context    The initialized TEE context structure in which scope to
+ *                   open the session.
+ * @param sharedMem  pointer to the shared memory structure to register.
+ *
+ * @return TEEC_SUCCESS              The registration was successful.
+ * @return TEEC_ERROR_OUT_OF_MEMORY  Memory exhaustion.
+ * @return TEEC_Result               Something failed.
+ */
+TEEC_Result TEEC_RegisterSharedMemory(TEEC_Context *context,
+				      TEEC_SharedMemory *sharedMem);
+
+/**
+ * TEEC_AllocateSharedMemory() - Allocate shared memory for TEE.
+ *
+ * @param context     The initialized TEE context structure in which scope to
+ *                    open the session.
+ * @param sharedMem   Pointer to the allocated shared memory.
+ *
+ * @return TEEC_SUCCESS              The registration was successful.
+ * @return TEEC_ERROR_OUT_OF_MEMORY  Memory exhaustion.
+ * @return TEEC_Result               Something failed.
+ */
+TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *context,
+				      TEEC_SharedMemory *sharedMem);
+
+/**
+ * TEEC_ReleaseSharedMemory() - Free or deregister the shared memory.
+ *
+ * @param sharedMem  Pointer to the shared memory to be freed.
+ */
+void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *sharedMemory);
+
+/**
+ * TEEC_RequestCancellation() - Request the cancellation of a pending open
+ *                              session or command invocation.
+ *
+ * @param operation Pointer to an operation previously passed to open session
+ *                  or invoke.
+ */
+void TEEC_RequestCancellation(TEEC_Operation *operation);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tee_client/public/tee_client_api_extensions.h
+++ b/tee_client/public/tee_client_api_extensions.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TEE_CLIENT_API_EXTENSIONS_H
+#define TEE_CLIENT_API_EXTENSIONS_H
+
+#include <tee_client_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * TEEC_RegisterMemoryFileDescriptor() - Register a block of existing memory as
+ * a shared block within the scope of the specified context.
+ *
+ * @param context    The initialized TEE context structure in which scope to
+ *                   open the session.
+ * @param sharedMem  pointer to the shared memory structure to register.
+ * @param fd         file descriptor of the target memory.
+ *
+ * @return TEEC_SUCCESS              The registration was successful.
+ * @return TEEC_ERROR_OUT_OF_MEMORY  Memory exhaustion.
+ * @return TEEC_Result               Something failed.
+ */
+TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *context,
+						    TEEC_SharedMemory *sharedMem,
+						    int fd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEE_CLIENT_API_EXTENSIONS_H */

--- a/tee_client/public/tee_types.h
+++ b/tee_client/public/tee_types.h
@@ -1,0 +1,126 @@
+/**
+ * @file        /mTower/apps/tee_types.h
+ * @brief       Short file description
+ *
+ * @copyright   Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+ * @author      Taras Drozdovskyi t.drozdovsky@samsung.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @todo
+ */
+
+#ifndef __APPS_TEE_TYPES_H_
+#define __APPS_TEE_TYPES_H_
+
+/* Included Files */
+/* All header files are included here. */
+#include <stddef.h>
+#include <stdint.h>
+
+/* Pre-processor Definitions */
+/* All C pre-processor macros are defined here. */
+
+#ifndef false
+#define false               (0)
+#endif
+
+#ifndef true
+#define true                (1)
+#endif
+
+#ifndef NULL
+#define NULL                ((void *)0)
+#endif
+
+/* Public Types */
+/* Any types, enumerations, structures or unions are defined here. */
+#ifndef __STDINT__
+
+#ifndef _INT8_T_DECLARED
+typedef signed char                int8_t;
+#endif
+typedef unsigned char       uint8_t;
+
+typedef short               int16_t;
+typedef unsigned short      uint16_t;
+
+#ifndef _INT32_T_DECLARED
+typedef int                 int32_t;
+#endif
+#ifndef _UINT32_T_DECLARED
+typedef unsigned int        uint32_t;
+#endif
+
+typedef long long           int64_t;
+typedef unsigned long long  uint64_t;
+
+//typedef unsigned long       size_t;
+//typedef long                ssize_t;
+
+typedef long                long_t;
+typedef unsigned long       ulong_t;
+
+//typedef unsigned long int   uintptr_t;
+
+#endif /* __STDINT__ */
+
+typedef unsigned char       bool;
+typedef uint32_t            tee_stat_t;
+
+
+/* Public Data */
+/* All data declarations with global scope appear here, preceded by
+ * the definition EXTERN.
+ */
+
+
+/* Inline Functions */
+/* Any static inline functions may be defined in this grouping.
+ * Each is preceded by a function header similar to the below.
+ */
+
+/**
+ * @brief         <Inline function name> - Description of the operation
+ *                of the static function.
+ *
+ * @param value   [in]/[out] A list of input parameters, one-per-line,
+ *                appears here along with a description of each input
+ *                parameter.
+ *
+ * @returns       Description of the value returned by this function
+ *                (if any), including an enumeration of all possible
+ *                error values.
+ */
+
+/* Public Function Prototypes */
+/* All global functions in the file are prototyped here. The keyword
+ * extern or the definition EXTERN are never used with function
+ * prototypes.
+ */
+
+/**
+ * @brief         <Global function name> - Description of the operation
+ *                of the static function.
+ *
+ * @param value   [in]/[out] A list of input parameters, one-per-line,
+ *                appears here along with a description of each input
+ *                parameter.
+ *
+ * @returns       Description of the value returned by this function
+ *                (if any), including an enumeration of all possible
+ *                error values.
+ */
+
+
+#endif /* __APPS_TEE_TYPES_H_ */

--- a/tee_client/public/teec_trace.h
+++ b/tee_client/public/teec_trace.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TEEC_TRACE_H
+#define TEEC_TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#ifndef BINARY_PREFIX
+#error "BINARY_PREFIX not defined"
+#endif
+
+/*
+ * Trace levels.
+ *
+ * ERROR is used when some kind of error has happened, this is most likely the
+ * print you will use most of the time when you report some kind of error.
+ *
+ * INFO is used when you want to print some 'normal' text to the user.
+ * This is the default level.
+ *
+ * DEBUG is used to print extra information to enter deeply in the module.
+ *
+ * FLOW is used to print the execution flox, typically the in/out of functions.
+ *
+ * */
+
+#define TRACE_ERROR  1
+#define TRACE_INFO   2
+#define TRACE_DEBUG  3
+#define TRACE_FLOW   4
+
+#if defined(DEBUGLEVEL_0) && !defined(DEBUGLEVEL)
+#define DEBUGLEVEL TRACE_ERROR
+#endif
+
+#if defined(DEBUGLEVEL_1) && !defined(DEBUGLEVEL)
+#define DEBUGLEVEL TRACE_ERROR
+#endif
+
+#if defined(DEBUGLEVEL_2) && !defined(DEBUGLEVEL)
+#define DEBUGLEVEL TRACE_INFO
+#endif
+
+#if defined(DEBUGLEVEL_3) && !defined(DEBUGLEVEL)
+#define DEBUGLEVEL TRACE_DEBUG
+#endif
+
+#if defined(DEBUGLEVEL_4) && !defined(DEBUGLEVEL)
+#define DEBUGLEVEL TRACE_FLOW
+#endif
+
+#ifndef DEBUGLEVEL
+/* Default debug level. */
+#define DEBUGLEVEL TRACE_INFO
+#endif
+
+/*
+ * This define make sure that parameters are checked in the same manner as it
+ * is done in the normal printf function.
+ */
+#define __PRINTFLIKE(__fmt, __varargs) __attribute__\
+	((__format__(__printf__, __fmt, __varargs)))
+
+int _dprintf(const char *function, int flen, int line, int level,
+	     const char *prefix, const char *fmt, ...) __PRINTFLIKE(6, 7);
+
+#define dprintf(level, x...) do { \
+		if ((level) <= DEBUGLEVEL) { \
+			_dprintf(__func__, strlen(__func__), __LINE__, level, \
+				 BINARY_PREFIX, x); \
+		} \
+	} while (0)
+
+#define EMSG(fmt, ...)   dprintf(TRACE_ERROR, fmt "\n", ##__VA_ARGS__)
+#define IMSG(fmt, ...)   dprintf(TRACE_INFO, fmt "\n", ##__VA_ARGS__)
+#define DMSG(fmt, ...)   dprintf(TRACE_DEBUG, fmt "\n", ##__VA_ARGS__)
+#define FMSG(fmt, ...)   dprintf(TRACE_FLOW, fmt "\n", ##__VA_ARGS__)
+
+#define INMSG(fmt, ...)  FMSG("> " fmt, ##__VA_ARGS__)
+#define OUTMSG(fmt, ...) FMSG("< " fmt, ##__VA_ARGS__)
+#define OUTRMSG(r)                              \
+	do {                                            \
+		if (r)                                      \
+			EMSG("Function returns with [%d]", r);  \
+		OUTMSG("r=[%d]", r);                        \
+		return r;                                   \
+	} while (0)
+
+#define dprintf_raw(level, x...) do { \
+		if ((level) <= DEBUGLEVEL) \
+			_dprintf(0, 0, 0, (level), BINARY_PREFIX, x); \
+	} while (0)
+
+#define EMSG_RAW(fmt, ...)   dprintf_raw(TRACE_ERROR, fmt, ##__VA_ARGS__)
+#define IMSG_RAW(fmt, ...)   dprintf_raw(TRACE_INFO, fmt, ##__VA_ARGS__)
+#define DMSG_RAW(fmt, ...)   dprintf_raw(TRACE_DEBUG, fmt, ##__VA_ARGS__)
+#define FMSG_RAW(fmt, ...)   dprintf_raw(TRACE_FLOW, fmt, ##__VA_ARGS__)
+
+/*
+ * This function will hex and ascii dump a buffer.
+ *
+ * Note that this function will only print if debug flag
+ * DEBUGLEVEL is INFO or FLOOD.
+ *
+ * @param bname     Information string describing the buffer.
+ * @param buffer    Pointer to the buffer.
+ * @param blen      Length of the buffer.
+ *
+ * @return void
+ */
+void dump_buffer(const char *bname, const uint8_t *buffer, size_t blen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
# Description

Partially implemented the GP TEE Client API (without shared memory) for normal world.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Normal world console:
```sh
        -=mTower v0.1=-  Mar 19 2019  16:42:26

+---------------------------------------------+
|     Nonsecure FreeRTOS is running ...       |
+---------------------------------------------+
Thread 1 test
Thread 2 test
Nonsecure LED On
Thread 3 test
test3           X       2       456     3
tee_test        R       2       502     4
IDLE            R       0       118     5
test2           B       2       118     2
test1           B       2       120     1
Tmr Svc         B       2       48      6

TEE test: Hello_world
TEEC_InitializeContext successfully with code 0x0
TEEC_Opensession successfully with code 0x0
Invoking TA to increment 42
TEEC_InvokeCommand successfully with code 0x0
TA incremented value to 43
Session successfully closed 0x2
Nonsecure LED Off
```
Secure world console:
```sh
        -=mTower v0.1=-  Mar 19 2019  16:40:26

+---------------------------------------------+
|              Secure is running ...          |
+---------------------------------------------+
Execute non-secure code ...
Secure NSC func
Secure LED On call by Non-secure
Secure ioctl: cmd = 2
arg->num_params = 4
arg->session = 0
arg->session = 2
UUID = 8aaaf200-2450-11e4-ab-e2-00-02-a5-d5-c5-1b
Secure ioctl: cmd = 3
arg->num_params = 4
arg->session = 2
params->u.value.a = 42
Secure ioctl: cmd = 5
arg->session = 2
Secure LED Off call by Non-secure
Secure LED On call by Non-secure
```

**Test Configuration**:
* Firmware version: v0.1
* Hardware: NuMaker-PFM-M2351
* Toolchain: GCC 6.1 or high

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules