### PR TITLE
Added detail info about binaries after build finish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@
 /pcode
 /tags
 toolchain/
-
+mtower_s.txt
+mtower_ns.txt

--- a/arch/cortex-m23/m2351/src/m2351_badge/Makefile
+++ b/arch/cortex-m23/m2351/src/m2351_badge/Makefile
@@ -35,6 +35,12 @@ mtower$(EXEEXT):
 ifeq ($(CONFIG_BOOTLOADER33),y)
 	$(Q) $(MAKE) -C nonsecure TOPDIR="$(TOPDIR)" mtower_ns$(EXEEXT)
 endif
+#ifeq ($(CONFIG_BOOTLOADER32),y)
+	$(Q) cat $(TOPDIR)/mtower_s.txt
+#endif
+ifeq ($(CONFIG_BOOTLOADER33),y)
+	$(Q) cat $(TOPDIR)/mtower_ns.txt
+endif
 
 clean:
 	$(Q) $(MAKE) -C secure TOPDIR="$(TOPDIR)" clean
@@ -42,8 +48,10 @@ clean:
 	$(Q) rm -rf $(TOPDIR)/build
 	$(Q) rm -f $(TOPDIR)/mtower_s.bin
 	$(Q) rm -f $(TOPDIR)/mtower_s.hex
+	$(Q) rf -f $(TOPDIR)/mtower_s.txt
 	$(Q) rm -f $(TOPDIR)/mtower_ns.bin
 	$(Q) rm -f $(TOPDIR)/mtower_ns.hex
+	$(Q) rf -f $(TOPDIR)/mtower_ns.txt
 
 distclean: clean
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/Makefile
@@ -35,6 +35,12 @@ mtower$(EXEEXT):
 ifeq ($(CONFIG_BOOTLOADER33),y)
 	$(Q) $(MAKE) -C nonsecure TOPDIR="$(TOPDIR)" mtower_ns$(EXEEXT)
 endif
+#ifeq ($(CONFIG_BOOTLOADER32),y)
+	$(Q) cat $(TOPDIR)/mtower_s.txt
+#endif
+ifeq ($(CONFIG_BOOTLOADER33),y)
+	$(Q) cat $(TOPDIR)/mtower_ns.txt
+endif
 
 clean:
 	$(Q) $(MAKE) -C secure TOPDIR="$(TOPDIR)" clean
@@ -42,8 +48,10 @@ clean:
 	$(Q) rm -rf $(TOPDIR)/build
 	$(Q) rm -f $(TOPDIR)/mtower_s.bin
 	$(Q) rm -f $(TOPDIR)/mtower_s.hex
+	$(Q) rf -f $(TOPDIR)/mtower_s.txt
 	$(Q) rm -f $(TOPDIR)/mtower_ns.bin
 	$(Q) rm -f $(TOPDIR)/mtower_ns.hex
+	$(Q) rf -f $(TOPDIR)/mtower_ns.txt
 
 distclean: clean
 

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/Makefile
@@ -83,6 +83,15 @@ mtower_ns$(EXEEXT): $(OBJS_NS)
 	$(Q) $(CC) $(CFLAGS) -Tnonsecure.ld $(OBJS_NS) $(LIBPATHS) $(LIBS) -o $(OBJDIR)/bl33.elf
 	$(Q) $(OBJCOPY) -S -O binary $(OBJDIR)/bl33.elf $(OBJDIR)/bl33.bin
 	$(Q) cp -f $(OBJDIR)/bl33.bin $(TOPDIR)/mtower_ns.bin
+	$(eval bl33_sz = `stat -c%s $(OBJDIR)/bl33.bin`)
+	$(eval bl33_start = 0x10040000)
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" > $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)| mtower_ns.bin                                                      |$(NORMAL)\n" >> $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)| Name            | Start addr  | End addr  | Size      | File name  |$(NORMAL)\n" >> $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)| FreeRTOS        | 0x%08x\t|           | %d\t| bl33.bin   |$(NORMAL)\n" $(bl33_start) $(bl33_sz) >> $(TOPDIR)/mtower_ns.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_ns.txt
 
 clean:
 	$(Q) rm -f *$(OBJEXT) *$(LIBEXT)

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/secure/Makefile
@@ -92,6 +92,15 @@ endif
 	$(Q) $(OBJCOPY) -S -O binary $(OBJDIR)/bl32.elf $(OBJDIR)/bl32.bin
 	$(Q) cp -f $(OBJDIR)/bl32.bin $(TOPDIR)/mtower_s.bin
 	$(Q) cp -f $(OBJDIR)/libnsc$(LIBEXT) $(TOPDIR)/lib/
+	$(eval bl32_sz = `stat -c%s $(OBJDIR)/bl32.bin`)
+	$(eval bl32_start = $(CONFIG_START_ADDRESS_BL32))
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" > $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)| mtower_s.bin                                                       |$(NORMAL)\n" >> $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)| Name            | Start addr  | End addr  | Size      | File name  |$(NORMAL)\n" >> $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)| Secure handler  | 0x%08x\t|           | %d\t| bl32.bin   |$(NORMAL)\n" $(bl32_start) $(bl32_sz) >> $(TOPDIR)/mtower_s.txt
+	$(Q) printf "$(GREEN)+--------------------------------------------------------------------+$(NORMAL)\n" >> $(TOPDIR)/mtower_s.txt
 
 clean:
 	$(Q) $(MAKE) -C ../../NuBL2 TOPDIR="$(TOPDIR)" clean


### PR DESCRIPTION
# Description
Added detail info about binaries after build finish

```
+--------------------------------------------------------------------+
| mtower_s.bin                                                       |
+--------------------------------------------------------------------+
| Name            | Start addr  | End addr  | Size      | File name  |
+--------------------------------------------------------------------+
| Secure handler  | 0x00000000	|           | 101692	| bl32.bin   |
+--------------------------------------------------------------------+
+--------------------------------------------------------------------+
| mtower_ns.bin                                                      |
+--------------------------------------------------------------------+
| Name            | Start addr  | End addr  | Size      | File name  |
+--------------------------------------------------------------------+
| FreeRTOS        | 0x10040000	|           | 68168	| bl33.bin   |
+--------------------------------------------------------------------+
make[1]: Leaving directory '/home/kiirk/projects/GIS/opensource/mTower_origin/arch/cortex-m23/m2351/src/numaker_pfm_m2351'
***********************************************
**** mTower has been successfully compiled ****
***********************************************
```