### PR TITLE
Fixed warning like as "type 'unsigned int' but argument has type 'uint32_t {aka long unsigned int}

### DIFF
--- a/arch/cortex-m23/m2351/src/m2351_badge/nonsecure/main_ns.c
+++ b/arch/cortex-m23/m2351/src/m2351_badge/nonsecure/main_ns.c
@@ -65,7 +65,6 @@ typedef int32_t (*funcptr)(uint32_t);
 /* Prototypes of all static functions in the file are provided here. */
 static void prvSetupHardware( void );
 
-static void App_Init(uint32_t u32BootBase);
 static void DEBUG_PORT_Init(void);
 
 /* NonSecure functions used for callbacks */
@@ -209,38 +208,6 @@ static void LED_Off(uint32_t us)
 
   printf("Nonsecure LED Off\n");
   PC1_NS = 1;
-}
-
-/**
- * @brief         App_Init.
- *
- * @param         None
- *
- * @returns       None
- */
-static void App_Init(uint32_t u32BootBase)
-{
-  funcptr fp;
-  uint32_t u32StackBase;
-
-  /* 2nd entry contains the address of the Reset_Handler (CMSIS-CORE) function */
-  fp = ((funcptr) (*(((uint32_t *) SCB->VTOR) + 1)));
-
-  /* Check if the stack is in secure SRAM space */
-  u32StackBase = M32(u32BootBase);
-  if ((u32StackBase >= 0x30000000UL) && (u32StackBase < 0x40000000UL)) {
-    printf("Execute non-secure code ...\n");
-    /* SCB.VTOR points to the target Secure vector table base address. */
-    SCB->VTOR = u32BootBase;
-
-    fp(0); /* Non-secure function call */
-  } else {
-    /* Something went wrong */
-    printf("No code in non-secure region!\n");
-
-    while (1)
-      ;
-  }
 }
 
 /**

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/main_ns.c
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/nonsecure/main_ns.c
@@ -65,7 +65,6 @@ typedef int32_t (*funcptr)(uint32_t);
 /* Prototypes of all static functions in the file are provided here. */
 static void prvSetupHardware( void );
 
-static void App_Init(uint32_t u32BootBase);
 static void DEBUG_PORT_Init(void);
 
 /* NonSecure functions used for callbacks */
@@ -207,38 +206,6 @@ static void LED_Off(uint32_t us)
 
   printf("Nonsecure LED Off\n");
   PC1_NS = 1;
-}
-
-/**
- * @brief         App_Init.
- *
- * @param         None
- *
- * @returns       None
- */
-static void App_Init(uint32_t u32BootBase)
-{
-  funcptr fp;
-  uint32_t u32StackBase;
-
-  /* 2nd entry contains the address of the Reset_Handler (CMSIS-CORE) function */
-  fp = ((funcptr) (*(((uint32_t *) SCB->VTOR) + 1)));
-
-  /* Check if the stack is in secure SRAM space */
-  u32StackBase = M32(u32BootBase);
-  if ((u32StackBase >= 0x30000000UL) && (u32StackBase < 0x40000000UL)) {
-    printf("Execute non-secure code ...\n");
-    /* SCB.VTOR points to the target Secure vector table base address. */
-    SCB->VTOR = u32BootBase;
-
-    fp(0); /* Non-secure function call */
-  } else {
-    /* Something went wrong */
-    printf("No code in non-secure region!\n");
-
-    while (1)
-      ;
-  }
 }
 
 /**

--- a/configs/m2351_badge/Make.defs
+++ b/configs/m2351_badge/Make.defs
@@ -58,7 +58,7 @@ ARCHCPUFLAGS += -mcpu=cortex-m23 -march=armv8-m.base
 
 ARCHINCLUDES  = -I$(TOPDIR)/include
 
-ARCHDEFINES = -D__ARM_FEATURE_DSP=0
+ARCHDEFINES = -D__ARM_FEATURE_DSP=0 -U__UINT32_TYPE__ -D__UINT32_TYPE__="unsigned int"
 
 CFLAGS  = -std=gnu99 -pipe -Wl,--gc-sections
 

--- a/configs/numaker_pfm_m2351/Make.defs
+++ b/configs/numaker_pfm_m2351/Make.defs
@@ -58,7 +58,7 @@ ARCHCPUFLAGS += -mcpu=cortex-m23 -march=armv8-m.base
 
 ARCHINCLUDES  = -I$(TOPDIR)/include
 
-ARCHDEFINES = -D__ARM_FEATURE_DSP=0
+ARCHDEFINES = -D__ARM_FEATURE_DSP=0 -U__UINT32_TYPE__ -D__UINT32_TYPE__="unsigned int"
 
 CFLAGS  = -std=gnu99 -pipe -Wl,--gc-sections
 


### PR DESCRIPTION
Fixed warning like as "type 'unsigned int' but argument has type 'uint32_t {aka long unsigned int}

```
retarget.c:389:50: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
             printf("  [0x%08x] 0x%04x %s R%d [0x%x]\n",addr, inst,
```