### PR TITLE
Added info about located FwInfo metadata of BL32 and BL33 into final …

### DIFF
--- a/arch/cortex-m23/m2351/src/m2351_badge/Makefile
+++ b/arch/cortex-m23/m2351/src/m2351_badge/Makefile
@@ -73,6 +73,10 @@ ifeq ($(CONFIG_BOOTLOADER32),y)
 	$(eval bl32_start = $(CONFIG_START_ADDRESS_BL32))
 
 	$(Q) printf "$(GREEN)| Secure handler  | 0x%08x | 0x%08x | %u\t| bl32.bin      |$(NORMAL)\n" $(bl32_start) $$(( $(bl32_start) + $(bl32_sz) )) $(bl32_sz)
+ifeq ($(CONFIG_BOOTLOADER2),y)
+	$(Q) printf "$(GREEN)| FW info of BL32 | 0x%08x | 0x%08x | %u\t| *auto gen*    |$(NORMAL)\n" 0x00038000 0x000380c0 192
+endif	
+	
 endif
 	$(eval mtower_s_sz = `stat -c%s $(TOPDIR)/mtower_s.bin`)
 	$(eval mtower_s_start = 0x00000000)
@@ -90,6 +94,9 @@ ifeq ($(CONFIG_BOOTLOADER33),y)
 	$(Q) printf "$(GREEN)| Name            | Start addr | End addr   | Size      | File name     |$(NORMAL)\n"
 	$(Q) printf "$(GREEN)+-----------------------------------------------------------------------+$(NORMAL)\n"
 	$(Q) printf "$(GREEN)| FreeRTOS        | 0x%08x | 0x%08x | %u\t| bl33.bin      |$(NORMAL)\n" $(bl33_start) $$(( $(bl33_start) + $(bl33_sz) )) $(bl33_sz)
+ifeq ($(CONFIG_BOOTLOADER2),y)
+	$(Q) printf "$(GREEN)| FW info of BL33 | 0x%08x | 0x%08x | %u\t| *auto gen*    |$(NORMAL)\n" 0x00078000 0x000780c0 192
+endif	
 	$(Q) printf "$(GREEN)+-----------------------------------------------------------------------+$(NORMAL)\n"
 	$(eval mtower_ns_sz = `stat -c%s $(TOPDIR)/mtower_ns.bin`)
 	$(eval mtower_ns_start = $(CONFIG_START_ADDRESS_BL33))

--- a/arch/cortex-m23/m2351/src/numaker_pfm_m2351/Makefile
+++ b/arch/cortex-m23/m2351/src/numaker_pfm_m2351/Makefile
@@ -75,6 +75,10 @@ ifeq ($(CONFIG_BOOTLOADER32),y)
 	$(eval bl32_start = $(CONFIG_START_ADDRESS_BL32))
 
 	$(Q) printf "$(GREEN)| Secure handler  | 0x%08x | 0x%08x | %u\t| bl32.bin      |$(NORMAL)\n" $(bl32_start) $$(( $(bl32_start) + $(bl32_sz) )) $(bl32_sz)
+ifeq ($(CONFIG_BOOTLOADER2),y)
+	$(Q) printf "$(GREEN)| FW info of BL32 | 0x%08x | 0x%08x | %u\t| *auto gen*    |$(NORMAL)\n" 0x00038000 0x000380c0 192
+endif	
+	
 endif
 	$(eval mtower_s_sz = `stat -c%s $(TOPDIR)/mtower_s.bin`)
 	$(eval mtower_s_start = 0x00000000)
@@ -92,6 +96,9 @@ ifeq ($(CONFIG_BOOTLOADER33),y)
 	$(Q) printf "$(GREEN)| Name            | Start addr | End addr   | Size      | File name     |$(NORMAL)\n"
 	$(Q) printf "$(GREEN)+-----------------------------------------------------------------------+$(NORMAL)\n"
 	$(Q) printf "$(GREEN)| FreeRTOS        | 0x%08x | 0x%08x | %u\t| bl33.bin      |$(NORMAL)\n" $(bl33_start) $$(( $(bl33_start) + $(bl33_sz) )) $(bl33_sz)
+ifeq ($(CONFIG_BOOTLOADER2),y)
+	$(Q) printf "$(GREEN)| FW info of BL33 | 0x%08x | 0x%08x | %u\t| *auto gen*    |$(NORMAL)\n" 0x00078000 0x000780c0 192
+endif	
 	$(Q) printf "$(GREEN)+-----------------------------------------------------------------------+$(NORMAL)\n"
 	$(eval mtower_ns_sz = `stat -c%s $(TOPDIR)/mtower_ns.bin`)
 	$(eval mtower_ns_start = $(CONFIG_START_ADDRESS_BL33))


### PR DESCRIPTION
…info table

# Description

Display full information about binary content file of mTower.

Fixes #27 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run build system

```
$ make
...
+-----------------------------------------------------------------------+
| Secure image                                                          |
+-----------------------------------------------------------------------+
| Name            | Start addr | End addr   | Size      | File name     |
+-----------------------------------------------------------------------+
| Boot loader 2   | 0x00000000 | 0x0000b934 | 47412	| bl2.bin       |
| Secure handler  | 0x00010000 | 0x00028d3c | 101692	| bl32.bin      |
| FW info of BL32 | 0x00038000 | 0x000380c0 | 192	| *auto gen*    |
+-----------------------------------------------------------------------+
| mtower_s        | 0x00000000 | 0x000380c0 | 229568	| mtower_s.bin  |
+-----------------------------------------------------------------------+
+-----------------------------------------------------------------------+
| Non-Secure image                                                      |
+-----------------------------------------------------------------------+
| Name            | Start addr | End addr   | Size      | File name     |
+-----------------------------------------------------------------------+
| FreeRTOS        | 0x10040000 | 0x10050a80 | 68224	| bl33.bin      |
| FW info of BL33 | 0x00078000 | 0x000780c0 | 192	| *auto gen*    |
+-----------------------------------------------------------------------+
| mtower_ns       | 0x10040000 | 0x100780c0 | 229568	| mtower_ns.bin |
+-----------------------------------------------------------------------+

```
**Test Configuration**:
* Firmware version: mTower v0.3
* Hardware: All
* Toolchain: GCC

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules