### PR TITLE
move common cmse definitions from BSP to tee

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security policy
+1. [Supported Versions](#1-supported-versions)  
+2. [Vulnerability Report](#2-vulnerability-report)  
+3. [Security Disclosure](#3-security-disclosure)  
+
+---
+
+## 1. Supported Versions
+
+We are releasing patches to eliminate vulnerabilities, you can see below:
+
+| Version     | Supported by |
+| ----------- | ------------ |
+| 0.1.x-0.4.x | N/A          |
+
+---
+
+## 2. Vulnerability Report
+
+The mTower command assigns the highest priority to all security bugs in mTower. We appreciate your efforts and
+responsible disclosure of information to eliminate vulnerabilities.
+
+Please report security bugs by emailing the Lead Maintenance Specialist at t.drozdovsky@samsung.com. marked "SECURITY" or create an issue in the repository.
+Our team will confirm your request and within 72 hours will try to prepare recommendations for elimination. Our team will keep you updated on the progress towards the fix until the full announcement of the patch release. During this process, the security team may request additional information or guidance.
+
+---
+
+## 3. Security Disclosure
+
+When a security group receives a security error report as previously mentioned, it is assigned the highest priority and the person in charge. This person will coordinate the patch and release process,
+including the following steps:
+
+  * Confirm the problem and identify the affected versions.
+  * Check the code to find any similar problems.
+  * Prepare fixes for all releases still in maintenance. These fixes will
+    released as quickly as possible.
+
+We suggest the following format when disclosing vulnerabilities:
+
+  * Your name and email.
+  * Include scope of vulnerability. Let us know who could use this exploit.
+  * Document steps to identify the vulnerability. It is important that we can reproduce your findings. 
+  * How to exploit vulnerability, give us an attack scenario.

--- a/tee/include/kernel/tee_cmse.h
+++ b/tee/include/kernel/tee_cmse.h
@@ -1,0 +1,43 @@
+/**
+ * @file        tee/include/kernel/tee_cmse.h
+ * @brief       mTower cmse macros definition
+ *
+ * @copyright   Copyright (c) 2021 Xiaomi Co., Ltd. All Rights Reserved.
+ * @author      Jacky Yang yangxinle@xiaomi.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ **/
+
+#ifndef KERNEL_TEE_CMSE_H
+#define KERNEL_TEE_CMSE_H
+
+#include <arm_cmse.h>
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3L)
+# if defined (__ICCARM__)
+#  define __NONSECURE_ENTRY       __cmse_nonsecure_entry
+#  define __NONSECURE_ENTRY_WEAK  __cmse_nonsecure_entry //__weak
+#  define __NONSECURE_CALL        __cmse_nonsecure_call
+# else
+#  define __NONSECURE_ENTRY       __attribute__((cmse_nonsecure_entry))
+#  define __NONSECURE_ENTRY_WEAK  __attribute__((cmse_nonsecure_entry,weak))
+#  define __NONSECURE_CALL        __attribute__((cmse_nonsecure_call))
+# endif
+#else
+# define __NONSECURE_ENTRY
+# define __NONSECURE_ENTRY_WEAK
+# define __NONSECURE_CALL
+#endif
+
+#endif /* KERNEL_TEE_CMSE_H */

--- a/tee/kernel/entry_std.c
+++ b/tee/kernel/entry_std.c
@@ -29,11 +29,8 @@
  */
 
 /* Included Files. */
-#include <arm_cmse.h>
 #include <stdio.h>
 #include <string.h>
-#include "M2351.h"
-#include "partition_M2351.h"
 
 /* GP TEE client API */
 #include "tee_types.h"
@@ -42,6 +39,7 @@
 #include "tee/uuid.h"
 
 #include <kernel/tee_ta_manager.h>
+#include <kernel/tee_cmse.h>
 
 /* Pre-processor Definitions. */
 


### PR DESCRIPTION
Signed-off-by: Jacky Yang <yangxinle@xiaomi.com>

# Description

we are porting new devices to mTower, and find tee has some dependency on BSP definitions, so we hope to seperate them apart.

Fixes #41 move common cmse definitions from BSP to tee

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] These are only definitions location change, build get passed for numaker_pfm_m2351


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules