### PR TITLE
riscv: fix unreachable external interrupt handler

### DIFF
--- a/freertos/portable/GCC/RISC-V/portASM.S
+++ b/freertos/portable/GCC/RISC-V/portASM.S
@@ -642,7 +642,6 @@ test_if_external_interrupt:			/* If there is a CLINT and the mtimer interrupt is
 	li		a1, 0x807FFFFF
 	and		t2, t2, a1
 	bne t2, t1, unrecoverable_error	/* Something as yet unhandled. */
-	j unrecoverable_error
 
 #endif /* portasmHAS_MTIME or portasmHAS_CLINT*/
 


### PR DESCRIPTION
The test_if_external_interrupt label contains a logical error where both branch conditions lead to unrecoverable_error, making the external interrupt handler unreachable.

# Description

Fix broken conditional branch in test_if_external_interrupt that prevented external interrupts from reaching their handler. Change the unconditional jump to unrecoverable_error to instead jump to external_interrupt when mcause matches machine external interrupt.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code cleanup/refactoring
- [ ] CI system update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules