### PR TITLE
freertos: riscv: fix t0 restore in ecall_yield

### DIFF
--- a/freertos/portable/GCC/RISC-V/portASM.S
+++ b/freertos/portable/GCC/RISC-V/portASM.S
@@ -529,7 +529,7 @@ ecall_end:
 
 ecall_yield:
 	/* restore t0 */
-	csrr t0, mstatus
+	csrr t0, mscratch
 	portSAVE_BaseReg
 	/* a4 = mepc
 	 * a5 = mstatus


### PR DESCRIPTION
In trap entry, t0 is saved to mscratch.

# Description

In trap entry, t0 is saved to mscratch (csrw mscratch, t0). In ecall_yield, the code attempted to restore t0 from mstatus. This would corrupt t0 with mstatus value instead of original t0

Retore t0, from mscratch instead of mstatus
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code cleanup/refactoring
- [ ] CI system update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules